### PR TITLE
fix: handle processing of an empty list or file

### DIFF
--- a/src/main/java/io/kestra/plugin/kafka/Produce.java
+++ b/src/main/java/io/kestra/plugin/kafka/Produce.java
@@ -204,7 +204,7 @@ public class Produce extends AbstractKafkaConnection implements RunnableTask<Pro
 
                         count = resultFlowable
                             .reduce(Integer::sum)
-                            .block();
+                            .blockOptional().orElse(0);
                     }
                 } else {
                     flowable = Flux.fromArray(((List<Object>) this.from).toArray());
@@ -212,7 +212,7 @@ public class Produce extends AbstractKafkaConnection implements RunnableTask<Pro
 
                     count = resultFlowable
                         .reduce(Integer::sum)
-                        .block();
+                        .blockOptional().orElse(0);
                 }
             } else {
                 producer.send(this.producerRecord(runContext, producer, (Map<String, Object>) this.from));


### PR DESCRIPTION
Fix a `NullPointerException` that occurred when processing an empty list or file.

Fixes #88 