### PR TITLE
fix: handle numeric types when generating Avro values

### DIFF
--- a/src/main/java/io/kestra/plugin/kafka/serdes/MapToGenericRecordSerializer.java
+++ b/src/main/java/io/kestra/plugin/kafka/serdes/MapToGenericRecordSerializer.java
@@ -47,10 +47,10 @@ public class MapToGenericRecordSerializer implements Serializer<Object> {
             case ARRAY -> buildArrayValue(schema, (Collection<?>) data);
             case ENUM -> buildEnumValue(schema, (String) data);
             case FIXED -> buildFixedValue(schema, (byte[]) data);
-            case INT -> asNumber(data).intValue();
-            case LONG -> asNumber(data).longValue();
-            case FLOAT -> asNumber(data).floatValue();
-            case DOUBLE -> asNumber(data).doubleValue();
+            case INT -> data instanceof Number number ? number.intValue() : data;
+            case LONG -> data instanceof Number number ? number.longValue() : data;
+            case FLOAT -> data instanceof Number number ? number.floatValue() : data;
+            case DOUBLE -> data instanceof Number number ? number.doubleValue() : data;
             case STRING, BYTES, BOOLEAN, NULL -> data;
         };
     }
@@ -88,9 +88,5 @@ public class MapToGenericRecordSerializer implements Serializer<Object> {
 
     private static GenericFixed buildFixedValue(Schema schema, byte[] data) {
         return new org.apache.avro.generic.GenericData.Fixed(schema, data);
-    }
-
-    private static Number asNumber(Object data) {
-        return (Number) data;
     }
 }

--- a/src/main/java/io/kestra/plugin/kafka/serdes/MapToGenericRecordSerializer.java
+++ b/src/main/java/io/kestra/plugin/kafka/serdes/MapToGenericRecordSerializer.java
@@ -47,7 +47,11 @@ public class MapToGenericRecordSerializer implements Serializer<Object> {
             case ARRAY -> buildArrayValue(schema, (Collection<?>) data);
             case ENUM -> buildEnumValue(schema, (String) data);
             case FIXED -> buildFixedValue(schema, (byte[]) data);
-            case STRING, BYTES, INT, LONG, FLOAT, DOUBLE, BOOLEAN, NULL -> data;
+            case INT -> asNumber(data).intValue();
+            case LONG -> asNumber(data).longValue();
+            case FLOAT -> asNumber(data).floatValue();
+            case DOUBLE -> asNumber(data).doubleValue();
+            case STRING, BYTES, BOOLEAN, NULL -> data;
         };
     }
 
@@ -84,5 +88,9 @@ public class MapToGenericRecordSerializer implements Serializer<Object> {
 
     private static GenericFixed buildFixedValue(Schema schema, byte[] data) {
         return new org.apache.avro.generic.GenericData.Fixed(schema, data);
+    }
+
+    private static Number asNumber(Object data) {
+        return (Number) data;
     }
 }

--- a/src/test/java/io/kestra/plugin/kafka/KafkaTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/KafkaTest.java
@@ -414,6 +414,72 @@ public class KafkaTest {
     }
 
     @Test
+    void produceAvro_withIntegerAsLong() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+        String topic = "tu_" + IdUtils.create();
+
+        Map<String, Object> value = Map.of("number", 42);
+
+        Produce task = Produce.builder()
+                .properties(Map.of("bootstrap.servers", this.bootstrap))
+                .serdeProperties(Map.of("schema.registry.url", this.registry))
+                .keySerializer(SerdeType.STRING)
+                .valueSerializer(SerdeType.AVRO)
+                .topic(topic)
+                .valueAvroSchema("""
+                        {
+                          "type": "record",
+                          "name": "Sample",
+                          "namespace": "io.kestra.examples",
+                          "fields": [
+                            {
+                              "name": "number",
+                              "type": "long"
+                            }
+                          ]
+                        }
+                        """)
+                .from(Map.of("value", value))
+                .build();
+
+        Produce.Output output = task.run(runContext);
+        assertThat(output.getMessagesCount(), is(1));
+    }
+
+    @Test
+    void produceAvro_withDoubleAsFloat() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+        String topic = "tu_" + IdUtils.create();
+
+        Map<String, Object> value = Map.of("number", 42.0d);
+
+        Produce task = Produce.builder()
+                .properties(Map.of("bootstrap.servers", this.bootstrap))
+                .serdeProperties(Map.of("schema.registry.url", this.registry))
+                .keySerializer(SerdeType.STRING)
+                .valueSerializer(SerdeType.AVRO)
+                .topic(topic)
+                .valueAvroSchema("""
+                        {
+                          "type": "record",
+                          "name": "Sample",
+                          "namespace": "io.kestra.examples",
+                          "fields": [
+                            {
+                              "name": "number",
+                              "type": "float"
+                            }
+                          ]
+                        }
+                        """)
+                .from(Map.of("value", value))
+                .build();
+
+        Produce.Output output = task.run(runContext);
+        assertThat(output.getMessagesCount(), is(1));
+    }
+
+    @Test
     void produceAvro_withUnion_andRecord() throws Exception {
         RunContext runContext = runContextFactory.of(ImmutableMap.of());
         String topic = "tu_" + IdUtils.create();


### PR DESCRIPTION
In addition to #94, this PR fixes the serialization of numeric values, for example, when Jackson deserializes an `Integer` from the file when the Avro schema expects a `Long`.