### PR TITLE
feat: add missing metrics

### DIFF
--- a/src/main/java/io/kestra/plugin/kafka/Consume.java
+++ b/src/main/java/io/kestra/plugin/kafka/Consume.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
@@ -123,6 +124,14 @@ import static io.kestra.core.utils.Rethrow.throwConsumer;
                     newLine: true
                     from: "{{ outputs.consume.uri }}"
                 """
+        )
+    },
+    metrics = {
+        @Metric(
+            name = "records",
+            type = Counter.TYPE,
+            unit = "records",
+            description = "Number of records consumed from Kafka topic."
         )
     }
 )

--- a/src/main/java/io/kestra/plugin/kafka/Produce.java
+++ b/src/main/java/io/kestra/plugin/kafka/Produce.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.kafka;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Data;
@@ -104,6 +105,14 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                       {"type":"record","name":"twitter_schema","namespace":"io.kestra.examples","fields":[{"name":"username","type":"string"},{"name\":"tweet","type":"string"}]}
                     valueSerializer: AVRO
                 """
+        )
+    },
+    metrics = {
+        @Metric(
+            name = "records",
+            type = Counter.TYPE,
+            unit = "records",
+            description = "Number of records sent to Kafka topic."
         )
     }
 )


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
Closes [#12199](https://github.com/kestra-io/kestra/issues/12199)
---

### Contributor Checklist ✅

- [x] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [x] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [x] Setup instructions included if needed (API keys, accounts, etc.).
- [x] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [x] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [x] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [x] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [x] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [x] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [x] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [x] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [x] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [x] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [x] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [x] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [x] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [x] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [x] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [x] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [x] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`).
- [x] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [x] Do not send back as outputs the same infos you already have in your properties.
- [x] If you do not have any output use `VoidOutput`.
- [x] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
