### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/kafka/Consume.java
+++ b/src/main/java/io/kestra/plugin/kafka/Consume.java
@@ -43,6 +43,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -183,12 +184,16 @@ import java.util.stream.StreamSupport;
     }
 )
 public class Consume extends AbstractKafkaConnection implements RunnableTask<Consume.Output>, ConsumeInterface {
+    @PluginProperty(group = "destination")
     private Object topic;
 
+    @PluginProperty(group = "destination")
     private Property<String> topicPattern;
 
+    @PluginProperty(group = "advanced")
     private Property<List<Integer>> partitions;
 
+    @PluginProperty(group = "advanced")
     private Property<String> groupId;
 
     @Schema(
@@ -215,20 +220,27 @@ public class Consume extends AbstractKafkaConnection implements RunnableTask<Con
     private Property<QueueAcknowledgeType> acknowledgeType = Property.ofValue(QueueAcknowledgeType.ACCEPT);
 
     @Builder.Default
+    @PluginProperty(group = "connection")
     private Property<SerdeType> keyDeserializer = Property.ofValue(SerdeType.STRING);
 
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<SerdeType> valueDeserializer = Property.ofValue(SerdeType.STRING);
 
+    @PluginProperty(group = "reliability")
     private OnSerdeError onSerdeError;
 
+    @PluginProperty(group = "advanced")
     private Property<String> since;
 
     @Builder.Default
+    @PluginProperty(group = "execution")
     private Property<Duration> pollDuration = Property.ofValue(Duration.ofSeconds(5));
 
+    @PluginProperty(group = "advanced")
     private Property<Integer> maxRecords;
 
+    @PluginProperty(group = "execution")
     private Property<Duration> maxDuration;
 
     @Getter(AccessLevel.PACKAGE)
@@ -238,6 +250,7 @@ public class Consume extends AbstractKafkaConnection implements RunnableTask<Con
         title = "Filter messages by Kafka headers",
         description = "Consume records only when all header key/value pairs match exactly (last header wins, UTF-8 comparison)"
     )
+    @PluginProperty(group = "processing")
     private Property<Map<String, String>> headerFilters;
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -732,6 +745,7 @@ public class Consume extends AbstractKafkaConnection implements RunnableTask<Con
     @VisibleForTesting
     static final class TopicPartitionsSubscription implements ConsumerSubscription {
 
+        @PluginProperty(group = "advanced")
         private final String groupId;
         private final List<String> topics;
         private final Long fromTimestamp;

--- a/src/main/java/io/kestra/plugin/kafka/ConsumeInterface.java
+++ b/src/main/java/io/kestra/plugin/kafka/ConsumeInterface.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Duration;
 
 import jakarta.validation.constraints.NotNull;
+import io.kestra.core.models.annotations.PluginProperty;
 
 public interface ConsumeInterface extends KafkaConsumerInterface {
 
@@ -13,12 +14,14 @@ public interface ConsumeInterface extends KafkaConsumerInterface {
         title = "Maximum records to consume before stopping",
         description = "Soft limit checked on each poll."
     )
+    @PluginProperty(group = "execution")
     Property<Integer> getMaxRecords();
 
     @Schema(
         title = "Maximum duration to wait before stopping",
         description = "Soft limit checked on each poll."
     )
+    @PluginProperty(group = "execution")
     Property<Duration> getMaxDuration();
 
     @Schema(
@@ -26,5 +29,6 @@ public interface ConsumeInterface extends KafkaConsumerInterface {
         description = "Maximum wait per poll when no records are available."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<Duration> getPollDuration();
 }

--- a/src/main/java/io/kestra/plugin/kafka/KafkaConnectionInterface.java
+++ b/src/main/java/io/kestra/plugin/kafka/KafkaConnectionInterface.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Map;
 import jakarta.validation.constraints.NotNull;
+import io.kestra.core.models.annotations.PluginProperty;
 public interface KafkaConnectionInterface {
     @Schema(
         title = "Kafka client properties",
@@ -13,11 +14,13 @@ public interface KafkaConnectionInterface {
             """
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<Map<String, String>> getProperties();
 
     @Schema(
         title="Serializer or deserializer properties",
         description = "Passed to serdes; `avro.use.logical.type.converters` is forced to true by default."
     )
+    @PluginProperty(group = "advanced")
     Property<Map<String, String>> getSerdeProperties();
 }

--- a/src/main/java/io/kestra/plugin/kafka/KafkaConsumerInterface.java
+++ b/src/main/java/io/kestra/plugin/kafka/KafkaConsumerInterface.java
@@ -15,24 +15,28 @@ public interface KafkaConsumerInterface {
         title = "Kafka topic(s) to consume from",
         description = "String or list of strings; mutually exclusive with `topicPattern`."
     )
+    @PluginProperty(group = "advanced")
     Object getTopic();
 
     @Schema(
         title = "Regex pattern of topics to consume from",
         description = "Subscribes to topics matching the pattern and receives dynamic partition assignments; mutually exclusive with `topic`."
     )
+    @PluginProperty(group = "advanced")
     Property<String> getTopicPattern();
 
     @Schema(
         title = "Specific partitions to consume",
         description = "Manually assign partitions; bypasses consumer group rebalancing."
     )
+    @PluginProperty(group = "advanced")
     Property<List<Integer>> getPartitions();
 
     @Schema(
         title = "Kafka consumer group ID",
         description = "Determines offset management; required when using `topicPattern` and mandatory for `groupType: SHARE` (share group)."
     )
+    @PluginProperty(group = "advanced")
     Property<String> getGroupId();
 
     @Schema(
@@ -44,6 +48,7 @@ public interface KafkaConsumerInterface {
             """
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<GroupType> getGroupType();
 
     @Schema(
@@ -56,6 +61,7 @@ public interface KafkaConsumerInterface {
             """
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<QueueAcknowledgeType> getAcknowledgeType();
 
     @Schema(
@@ -63,6 +69,7 @@ public interface KafkaConsumerInterface {
         description = "Default STRING. Options: `STRING`, `INTEGER`, `FLOAT`, `DOUBLE`, `LONG`, `SHORT`, `BYTE_ARRAY`, `BYTE_BUFFER`, `BYTES`, `UUID`, `VOID`, `AVRO`, `JSON`."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<SerdeType> getKeyDeserializer();
 
     @Schema(
@@ -70,19 +77,21 @@ public interface KafkaConsumerInterface {
         description = "Default STRING. Options: `STRING`, `INTEGER`, `FLOAT`, `DOUBLE`, `LONG`, `SHORT`, `BYTE_ARRAY`, `BYTE_BUFFER`, `BYTES`, `UUID`, `VOID`, `AVRO`, `JSON`."
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<SerdeType> getValueDeserializer();
 
     @Schema(
         title = "Timestamp to start consuming from",
         description = "ISO-8601 instant used when no consumer group offsets exist; ignored when a consumer group controls offsets."
     )
+    @PluginProperty(group = "advanced")
     Property<String> getSince();
 
     @Schema(
         title = "Behavior on serde error",
         description = "Applies when valueDeserializer is JSON: `SKIPPED` (default), `STORE` to internal storage, or `DLQ` to the configured topic."
     )
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     OnSerdeError getOnSerdeError();
 
     @Builder

--- a/src/main/java/io/kestra/plugin/kafka/Produce.java
+++ b/src/main/java/io/kestra/plugin/kafka/Produce.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import jakarta.validation.constraints.NotNull;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -150,8 +151,10 @@ public class Produce extends AbstractKafkaConnection implements RunnableTask<Pro
         title = "Target Kafka topic when not provided in payload",
         description = "Can be overridden per record by setting `topic` inside `from`."
     )
+    @PluginProperty(group = "destination")
     private Property<String> topic;
 
+    @PluginProperty(group = "source")
     private Object from;
 
     @Schema(
@@ -160,6 +163,7 @@ public class Produce extends AbstractKafkaConnection implements RunnableTask<Pro
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "connection")
     private Property<SerdeType> keySerializer = Property.ofValue(SerdeType.STRING);
 
     @Schema(
@@ -168,18 +172,21 @@ public class Produce extends AbstractKafkaConnection implements RunnableTask<Pro
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<SerdeType> valueSerializer = Property.ofValue(SerdeType.STRING);
 
     @Schema(
         title = "Avro schema when the key serializer is AVRO",
         description = "Required if `keySerializer` is `AVRO`."
     )
+    @PluginProperty(group = "connection")
     private Property<String> keyAvroSchema;
 
     @Schema(
         title = "Avro schema when the value serializer is AVRO",
         description = "Required if `valueSerializer` is `AVRO`."
     )
+    @PluginProperty(group = "connection")
     private Property<String> valueAvroSchema;
 
     @Schema(
@@ -187,6 +194,7 @@ public class Produce extends AbstractKafkaConnection implements RunnableTask<Pro
         description = "Defaults to true; generates a transactional.id automatically so sends are committed atomically."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> transactional = Property.ofValue(true);
 
     @Builder.Default

--- a/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
@@ -30,6 +30,7 @@ import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -155,6 +156,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             """
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<GroupType> groupType = Property.ofValue(GroupType.CONSUMER);
 
     @Schema(
@@ -167,6 +169,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             """
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<QueueAcknowledgeType> acknowledgeType = Property.ofValue(QueueAcknowledgeType.ACCEPT);
 
     @Builder.Default
@@ -199,6 +202,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         title = "Filter messages by Kafka headers",
         description = "Consume records only when all header key/value pairs match exactly (last header wins, UTF-8 comparison)"
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, String>> headerFilters;
 
     protected Consume consumeTask() {

--- a/src/main/java/io/kestra/plugin/kafka/Trigger.java
+++ b/src/main/java/io/kestra/plugin/kafka/Trigger.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 
 import java.time.Duration;
 import java.util.*;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -112,6 +113,7 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
             """
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<GroupType> groupType = Property.ofValue(GroupType.CONSUMER);
 
     @Schema(
@@ -124,6 +126,7 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
             """
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<QueueAcknowledgeType> acknowledgeType = Property.ofValue(QueueAcknowledgeType.ACCEPT);
 
     @Builder.Default
@@ -147,6 +150,7 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
         title = "Filter messages by Kafka headers",
         description = "Consume records only when all header key/value pairs match exactly (last header wins, UTF-8 comparison)"
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, String>> headerFilters;
 
     protected Consume consumeTask() {


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712