### PR TITLE
feat(trigger): log Kafka RealtimeTrigger connection lifecycle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,8 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest-library"
 
     testImplementation "org.wiremock:wiremock-jetty12"
+
+    testImplementation "ch.qos.logback:logback-classic"
 }
 
 /**********************************************************************************************************************\

--- a/src/main/java/io/kestra/plugin/kafka/Consume.java
+++ b/src/main/java/io/kestra/plugin/kafka/Consume.java
@@ -711,6 +711,11 @@ public class Consume extends AbstractKafkaConnection implements RunnableTask<Con
 
         void subscribe(RunContext runContext, Consumer<Object, Object> consumer, ConsumeInterface consumeInterface) throws IllegalVariableEvaluationException;
 
+        default void subscribe(RunContext runContext, Consumer<Object, Object> consumer, ConsumeInterface consumeInterface,
+                               ConsumerRebalanceListener rebalanceListener) throws IllegalVariableEvaluationException {
+            subscribe(runContext, consumer, consumeInterface);
+        }
+
         default void waitForSubscription(RunContext runContext,
                                          final Consumer<Object, Object> consumer,
                                          final ConsumeInterface consumeInterface) throws IllegalVariableEvaluationException {
@@ -734,6 +739,12 @@ public class Consume extends AbstractKafkaConnection implements RunnableTask<Con
         }
 
         @Override
+        public void subscribe(RunContext runContext, final Consumer<Object, Object> consumer,
+                              final ConsumeInterface consumeInterface, final ConsumerRebalanceListener rebalanceListener) {
+            consumer.subscribe(pattern, rebalanceListener);
+        }
+
+        @Override
         public String toString() {
             return "[Subscription pattern=" + pattern + ", groupId=" + groupId + "]";
         }
@@ -748,6 +759,13 @@ public class Consume extends AbstractKafkaConnection implements RunnableTask<Con
         @Override
         public void subscribe(RunContext runContext, final Consumer<Object, Object> consumer, final ConsumeInterface consumeInterface) throws IllegalVariableEvaluationException {
             consumer.subscribe(topics);
+            waitForSubscription(runContext, consumer, consumeInterface);
+        }
+
+        @Override
+        public void subscribe(RunContext runContext, final Consumer<Object, Object> consumer,
+                              final ConsumeInterface consumeInterface, final ConsumerRebalanceListener rebalanceListener) throws IllegalVariableEvaluationException {
+            consumer.subscribe(topics, rebalanceListener);
             waitForSubscription(runContext, consumer, consumeInterface);
         }
 
@@ -798,11 +816,22 @@ public class Consume extends AbstractKafkaConnection implements RunnableTask<Con
 
         @Override
         public void subscribe(RunContext runContext, final Consumer<Object, Object> consumer, final ConsumeInterface consumeInterface) {
+            subscribe(runContext, consumer, consumeInterface, null);
+        }
+
+        @Override
+        public void subscribe(RunContext runContext, final Consumer<Object, Object> consumer,
+                              final ConsumeInterface consumeInterface, final ConsumerRebalanceListener rebalanceListener) {
             if (this.topicPartitions == null) {
                 this.topicPartitions = allPartitionsForTopics(consumer, topics);
             }
 
             consumer.assign(this.topicPartitions);
+            // assign() does not trigger rebalance callbacks — notify listener immediately after assignment
+            if (rebalanceListener != null) {
+                rebalanceListener.onPartitionsAssigned(this.topicPartitions);
+            }
+
             if (this.fromTimestamp == null) {
                 consumer.seekToBeginning(this.topicPartitions);
                 return;

--- a/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicReference;
         In `groupType: SHARE`, behavior is queue semantics with share groups and explicit acknowledgements.
         In `SHARE` mode, use `topic` with `groupId`; `topicPattern`, `partitions`, and `since` are not supported.
         Use header filters to drop unmatched records. Prefer the batch [Kafka Trigger](https://kestra.io/plugins/plugin-kafka/triggers/io.kestra.plugin.kafka.trigger) for interval-based pulls.
-        Emits INFO logs on startup, subscription, connection confirmation, and shutdown — grep by triggerId to verify Kafka connectivity.
+        Emits DEBUG logs on startup, subscription, connection confirmation, and shutdown — grep by triggerId to verify Kafka connectivity.
         """
 )
 @Plugin(
@@ -258,7 +258,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 var rValueDeserializer = runContext.render(this.valueDeserializer).as(SerdeType.class).orElse(SerdeType.STRING);
                 var bootstrapServers = rProperties.get("bootstrap.servers");
 
-                runContext.logger().info(
+                runContext.logger().debug(
                     "Starting Kafka trigger triggerId={} bootstrap.servers={} groupId={} groupType={} topics={} topicPattern={} partitions={} keyDeserializer={} valueDeserializer={}",
                     this.id, bootstrapServers, rGroupId, rGroupType,
                     this.topic, this.topicPattern, this.partitions,
@@ -271,7 +271,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                     runWithConsumer(task, runContext, fluxSink);
                 }
             } catch (WakeupException e) {
-                runContext.logger().info("Kafka trigger triggerId={} woken up; stopping poll loop", this.id);
+                runContext.logger().debug("Kafka trigger triggerId={} woken up; stopping poll loop", this.id);
             } catch (Exception e) {
                 runContext.logger().error("Kafka trigger triggerId={} failed with error: {}", this.id, e.getMessage());
                 fluxSink.error(e);
@@ -288,7 +288,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         Logger logger = runContext.logger();
         try (KafkaConsumer<Object, Object> consumer = task.consumer(runContext)) {
             this.consumer.set(consumer);
-            logger.info("Kafka consumer created for triggerId={} groupId={} groupType=CONSUMER", this.id, runContext.render(this.groupId).as(String.class).orElse(null));
+            logger.debug("Kafka consumer created for triggerId={} groupId={} groupType=CONSUMER", this.id, runContext.render(this.groupId).as(String.class).orElse(null));
 
             var subscription = task.topicSubscription(runContext);
             var firstAssignment = new AtomicBoolean(false);
@@ -296,7 +296,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 @Override
                 public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
                     if (firstAssignment.compareAndSet(false, true)) {
-                        logger.info("Kafka connection established for triggerId={}: partitions assigned = {}", RealtimeTrigger.this.id, partitions);
+                        logger.debug("Kafka connection established for triggerId={}: partitions assigned = {}", RealtimeTrigger.this.id, partitions);
                     }
                 }
 
@@ -307,7 +307,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             };
             subscription.subscribe(runContext, consumer, task, rebalanceListener);
 
-            logger.info(
+            logger.debug(
                 "Subscribed for triggerId={}: topics={} topicPattern={} partitions={}",
                 this.id,
                 this.topic,
@@ -330,10 +330,10 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         task.validateShareConfiguration();
         try (var consumer = task.shareConsumer(runContext)) {
             this.shareConsumer.set(consumer);
-            logger.info("Kafka consumer created for triggerId={} groupId={} groupType=SHARE", this.id, runContext.render(this.groupId).as(String.class).orElse(null));
+            logger.debug("Kafka consumer created for triggerId={} groupId={} groupType=SHARE", this.id, runContext.render(this.groupId).as(String.class).orElse(null));
 
             task.shareSubscribe(runContext, consumer);
-            logger.info(
+            logger.debug(
                 "Subscribed for triggerId={}: topics={} topicPattern={} partitions={}",
                 this.id,
                 this.topic,
@@ -345,7 +345,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             runPollingLoop(() -> {
                 var records = consumer.poll(Duration.ofMillis(Long.MAX_VALUE));
                 if (!records.isEmpty() && firstShareBatch.compareAndSet(false, true)) {
-                    logger.info("Kafka SHARE connection confirmed for triggerId={}: first batch received ({} records)", this.id, records.count());
+                    logger.debug("Kafka SHARE connection confirmed for triggerId={}: first batch received ({} records)", this.id, records.count());
                 }
                 task.processShareConsumerRecords(runContext, consumer, records, fluxSink::next);
                 consumer.commitSync();
@@ -395,7 +395,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
         // Logging here requires a stable logger reference since RunContext may not be available
         org.slf4j.LoggerFactory.getLogger(RealtimeTrigger.class)
-            .info("Stopping Kafka trigger triggerId={} (wait={})", this.id, wait);
+            .debug("Stopping Kafka trigger triggerId={} (wait={})", this.id, wait);
 
         var hasConsumer = consumer.get() != null || shareConsumer.get() != null;
         Optional.ofNullable(consumer.get()).ifPresent(Consumer::wakeup);

--- a/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
@@ -250,6 +250,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     public Publisher<ConsumerRecord<Object, Object>> publisher(final Consume task,
                                                                final RunContext runContext) {
         return Flux.create(fluxSink -> {
+            var logger = runContext.logger();
             try {
                 var rProperties = runContext.render(this.properties).asMap(String.class, String.class);
                 var rGroupId = runContext.render(this.groupId).as(String.class).orElse(null);
@@ -258,7 +259,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 var rValueDeserializer = runContext.render(this.valueDeserializer).as(SerdeType.class).orElse(SerdeType.STRING);
                 var bootstrapServers = rProperties.get("bootstrap.servers");
 
-                runContext.logger().debug(
+                logger.debug(
                     "Starting Kafka trigger triggerId={} bootstrap.servers={} groupId={} groupType={} topics={} topicPattern={} partitions={} keyDeserializer={} valueDeserializer={}",
                     this.id, bootstrapServers, rGroupId, rGroupType,
                     this.topic, this.topicPattern, this.partitions,
@@ -271,9 +272,9 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                     runWithConsumer(task, runContext, fluxSink);
                 }
             } catch (WakeupException e) {
-                runContext.logger().debug("Kafka trigger triggerId={} woken up; stopping poll loop", this.id);
+                logger.debug("Kafka trigger triggerId={} woken up; stopping poll loop", this.id);
             } catch (Exception e) {
-                runContext.logger().error("Kafka trigger triggerId={} failed with error: {}", this.id, e.getMessage());
+                logger.error("Kafka trigger triggerId={} failed with error: {}", this.id, e.getMessage());
                 fluxSink.error(e);
             } finally {
                 fluxSink.complete();
@@ -344,6 +345,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             var firstShareBatch = new AtomicBoolean(false);
             runPollingLoop(() -> {
                 var records = consumer.poll(Duration.ofMillis(Long.MAX_VALUE));
+                // compareAndSet flips the flag and returns true only on the first non-empty batch, so this logs once
                 if (!records.isEmpty() && firstShareBatch.compareAndSet(false, true)) {
                     logger.debug("Kafka SHARE connection confirmed for triggerId={}: first batch received ({} records)", this.id, records.count());
                 }

--- a/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
@@ -19,13 +19,16 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.ShareConsumer;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
+import org.slf4j.Logger;
 
 import java.time.Duration;
 import java.util.*;
@@ -47,6 +50,7 @@ import java.util.concurrent.atomic.AtomicReference;
         In `groupType: SHARE`, behavior is queue semantics with share groups and explicit acknowledgements.
         In `SHARE` mode, use `topic` with `groupId`; `topicPattern`, `partitions`, and `since` are not supported.
         Use header filters to drop unmatched records. Prefer the batch [Kafka Trigger](https://kestra.io/plugins/plugin-kafka/triggers/io.kestra.plugin.kafka.trigger) for interval-based pulls.
+        Emits INFO logs on startup, subscription, connection confirmation, and shutdown — grep by triggerId to verify Kafka connectivity.
         """
 )
 @Plugin(
@@ -247,14 +251,29 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                                                                final RunContext runContext) {
         return Flux.create(fluxSink -> {
             try {
-                if (task.resolveGroupType(runContext) == GroupType.SHARE) {
+                var rProperties = runContext.render(this.properties).asMap(String.class, String.class);
+                var rGroupId = runContext.render(this.groupId).as(String.class).orElse(null);
+                var rGroupType = task.resolveGroupType(runContext);
+                var rKeyDeserializer = runContext.render(this.keyDeserializer).as(SerdeType.class).orElse(SerdeType.STRING);
+                var rValueDeserializer = runContext.render(this.valueDeserializer).as(SerdeType.class).orElse(SerdeType.STRING);
+                var bootstrapServers = rProperties.get("bootstrap.servers");
+
+                runContext.logger().info(
+                    "Starting Kafka trigger triggerId={} bootstrap.servers={} groupId={} groupType={} topics={} topicPattern={} partitions={} keyDeserializer={} valueDeserializer={}",
+                    this.id, bootstrapServers, rGroupId, rGroupType,
+                    this.topic, this.topicPattern, this.partitions,
+                    rKeyDeserializer, rValueDeserializer
+                );
+
+                if (rGroupType == GroupType.SHARE) {
                     runWithShareConsumer(task, runContext, fluxSink);
                 } else {
                     runWithConsumer(task, runContext, fluxSink);
                 }
             } catch (WakeupException e) {
-                // ignore and stop
+                runContext.logger().info("Kafka trigger triggerId={} woken up; stopping poll loop", this.id);
             } catch (Exception e) {
+                runContext.logger().error("Kafka trigger triggerId={} failed with error: {}", this.id, e.getMessage());
                 fluxSink.error(e);
             } finally {
                 fluxSink.complete();
@@ -266,9 +285,36 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     private void runWithConsumer(Consume task,
                                  RunContext runContext,
                                  FluxSink<ConsumerRecord<Object, Object>> fluxSink) throws Exception {
+        Logger logger = runContext.logger();
         try (KafkaConsumer<Object, Object> consumer = task.consumer(runContext)) {
             this.consumer.set(consumer);
-            task.topicSubscription(runContext).subscribe(runContext, consumer, task);
+            logger.info("Kafka consumer created for triggerId={} groupId={} groupType=CONSUMER", this.id, runContext.render(this.groupId).as(String.class).orElse(null));
+
+            var subscription = task.topicSubscription(runContext);
+            var firstAssignment = new AtomicBoolean(false);
+            var rebalanceListener = new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+                    if (firstAssignment.compareAndSet(false, true)) {
+                        logger.info("Kafka connection established for triggerId={}: partitions assigned = {}", RealtimeTrigger.this.id, partitions);
+                    }
+                }
+
+                @Override
+                public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+                    // intentionally left blank — revocation does not change connection state
+                }
+            };
+            subscription.subscribe(runContext, consumer, task, rebalanceListener);
+
+            logger.info(
+                "Subscribed for triggerId={}: topics={} topicPattern={} partitions={}",
+                this.id,
+                this.topic,
+                this.topicPattern,
+                this.partitions
+            );
+
             runPollingLoop(() -> {
                 var records = consumer.poll(Duration.ofMillis(Long.MAX_VALUE));
                 task.processConsumerRecords(runContext, records, fluxSink::next);
@@ -280,12 +326,27 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     private void runWithShareConsumer(Consume task,
                                       RunContext runContext,
                                       FluxSink<ConsumerRecord<Object, Object>> fluxSink) throws Exception {
+        Logger logger = runContext.logger();
         task.validateShareConfiguration();
         try (var consumer = task.shareConsumer(runContext)) {
             this.shareConsumer.set(consumer);
+            logger.info("Kafka consumer created for triggerId={} groupId={} groupType=SHARE", this.id, runContext.render(this.groupId).as(String.class).orElse(null));
+
             task.shareSubscribe(runContext, consumer);
+            logger.info(
+                "Subscribed for triggerId={}: topics={} topicPattern={} partitions={}",
+                this.id,
+                this.topic,
+                this.topicPattern,
+                this.partitions
+            );
+
+            var firstShareBatch = new AtomicBoolean(false);
             runPollingLoop(() -> {
                 var records = consumer.poll(Duration.ofMillis(Long.MAX_VALUE));
+                if (!records.isEmpty() && firstShareBatch.compareAndSet(false, true)) {
+                    logger.info("Kafka SHARE connection confirmed for triggerId={}: first batch received ({} records)", this.id, records.count());
+                }
                 task.processShareConsumerRecords(runContext, consumer, records, fluxSink::next);
                 consumer.commitSync();
             });
@@ -331,6 +392,10 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         if (!isActive.compareAndSet(true, false)) {
             return;
         }
+
+        // Logging here requires a stable logger reference since RunContext may not be available
+        org.slf4j.LoggerFactory.getLogger(RealtimeTrigger.class)
+            .info("Stopping Kafka trigger triggerId={} (wait={})", this.id, wait);
 
         var hasConsumer = consumer.get() != null || shareConsumer.get() != null;
         Optional.ofNullable(consumer.get()).ifPresent(Consumer::wakeup);

--- a/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
@@ -1,22 +1,33 @@
 package io.kestra.plugin.kafka;
 
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.queues.QueueFactoryInterface;
 import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.repositories.LocalFlowRepositoryLoader;
+import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.kafka.serdes.SerdeType;
 import io.micronaut.context.annotation.Value;
 import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -25,8 +36,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 @KestraTest(startRunner = true, startScheduler = true)
 class RealtimeTriggerTest {
@@ -79,6 +89,149 @@ class RealtimeTriggerTest {
         assertThat(executionList.stream()
             .anyMatch(execution -> "key2".equals(execution.getTrigger().getVariables().get("key"))), is(true));
         receive.blockLast();
+    }
+
+    @Test
+    void shouldEmitStartupAndSubscriptionLogs() throws Exception {
+        var triggerId = IdUtils.create();
+        var topic = "tu_logs_" + IdUtils.create();
+
+        var trigger = RealtimeTrigger.builder()
+            .id(triggerId)
+            .type(RealtimeTrigger.class.getName())
+            .topic(topic)
+            .groupId(Property.ofValue("test-group-" + IdUtils.create()))
+            .properties(Property.ofValue(Map.of(
+                "bootstrap.servers", this.bootstrap,
+                "auto.offset.reset", "earliest"
+            )))
+            .serdeProperties(Property.ofValue(Map.of("schema.registry.url", this.registry)))
+            .keyDeserializer(Property.ofValue(SerdeType.STRING))
+            .valueDeserializer(Property.ofValue(SerdeType.STRING))
+            .build();
+
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        // runContext.logger() returns a Logback logger from an isolated LoggerContext inside RunContextLogger.
+        // Cast it to attach our ListAppender directly, ensuring we capture logs regardless of global config.
+        var contextLogger = (Logger) runContext.logger();
+        contextLogger.setLevel(Level.INFO);
+        var listAppender = new ListAppender<ILoggingEvent>();
+        listAppender.setContext(contextLogger.getLoggerContext());
+        listAppender.start();
+        contextLogger.addAppender(listAppender);
+
+        try {
+            Consume task = trigger.consumeTask();
+            Publisher<ConsumerRecord<Object, Object>> publisher = trigger.publisher(task, runContext);
+
+            // subscribeOn puts the blocking Flux.create lambda on a background thread
+            Flux.from(publisher)
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(record -> {}, err -> {});
+
+            // Poll until the "Subscribed for triggerId" log appears (emitted before the first blocking poll)
+            var deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+            var found = false;
+            while (System.currentTimeMillis() < deadline) {
+                found = listAppender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .anyMatch(m -> m.contains("Subscribed for triggerId=") && m.contains(triggerId));
+                if (found) {
+                    break;
+                }
+                Thread.sleep(200);
+            }
+
+            trigger.stop();
+
+            assertThat("Timed out waiting for subscription log", found, is(true));
+
+            var logMessages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+            assertThat(
+                "Startup log must contain triggerId",
+                logMessages.stream().anyMatch(m -> m.contains("triggerId=" + triggerId)),
+                is(true)
+            );
+            assertThat(
+                "Startup log must include bootstrap.servers value",
+                logMessages.stream().anyMatch(m -> m.contains("bootstrap.servers=") && m.contains(this.bootstrap)),
+                is(true)
+            );
+            assertThat(
+                "Subscription log must contain the configured topic name",
+                logMessages.stream().anyMatch(m -> m.contains("Subscribed for triggerId=") && m.contains(topic)),
+                is(true)
+            );
+            assertThat(
+                "Consumer creation log must be present with CONSUMER group type",
+                logMessages.stream().anyMatch(m -> m.contains("Kafka consumer created for triggerId=") && m.contains("groupType=CONSUMER")),
+                is(true)
+            );
+        } finally {
+            contextLogger.detachAppender(listAppender);
+        }
+    }
+
+    @Test
+    void shouldEmitShutdownLog() throws Exception {
+        var triggerId = IdUtils.create();
+        var topic = "tu_shutdown_" + IdUtils.create();
+
+        var trigger = RealtimeTrigger.builder()
+            .id(triggerId)
+            .type(RealtimeTrigger.class.getName())
+            .topic(topic)
+            .groupId(Property.ofValue("test-group-" + IdUtils.create()))
+            .properties(Property.ofValue(Map.of(
+                "bootstrap.servers", this.bootstrap,
+                "auto.offset.reset", "earliest"
+            )))
+            .serdeProperties(Property.ofValue(Map.of("schema.registry.url", this.registry)))
+            .build();
+
+        // stop() uses LoggerFactory.getLogger(RealtimeTrigger.class) — set level and attach appender there
+        var triggerLogger = (Logger) LoggerFactory.getLogger(RealtimeTrigger.class);
+        triggerLogger.setLevel(Level.INFO);
+        var listAppender = new ListAppender<ILoggingEvent>();
+        listAppender.setContext(triggerLogger.getLoggerContext());
+        listAppender.start();
+        triggerLogger.addAppender(listAppender);
+
+        try {
+            RunContext runContext = runContextFactory.of(Map.of());
+            Consume task = trigger.consumeTask();
+
+            Publisher<ConsumerRecord<Object, Object>> publisher = trigger.publisher(task, runContext);
+
+            // Start on background thread, wait a bit for startup, then stop
+            Flux.from(publisher)
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(record -> {}, err -> {});
+
+            // Wait until the consumer is created (topic subscription blocks in poll)
+            Thread.sleep(Duration.ofSeconds(4).toMillis());
+
+            trigger.stop();
+
+            // Allow wakeup to propagate and shutdown log to be written
+            Thread.sleep(Duration.ofSeconds(2).toMillis());
+
+            var logMessages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+            assertThat(
+                "Shutdown log must be emitted containing triggerId",
+                logMessages.stream().anyMatch(m -> m.contains("Stopping Kafka trigger triggerId=") && m.contains(triggerId)),
+                is(true)
+            );
+        } finally {
+            triggerLogger.detachAppender(listAppender);
+        }
     }
 
     void produce() throws Exception {

--- a/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
@@ -115,7 +115,7 @@ class RealtimeTriggerTest {
         // runContext.logger() returns a Logback logger from an isolated LoggerContext inside RunContextLogger.
         // Cast it to attach our ListAppender directly, ensuring we capture logs regardless of global config.
         var contextLogger = (Logger) runContext.logger();
-        contextLogger.setLevel(Level.INFO);
+        contextLogger.setLevel(Level.DEBUG);
         var listAppender = new ListAppender<ILoggingEvent>();
         listAppender.setContext(contextLogger.getLoggerContext());
         listAppender.start();
@@ -195,7 +195,7 @@ class RealtimeTriggerTest {
 
         // stop() uses LoggerFactory.getLogger(RealtimeTrigger.class) — set level and attach appender there
         var triggerLogger = (Logger) LoggerFactory.getLogger(RealtimeTrigger.class);
-        triggerLogger.setLevel(Level.INFO);
+        triggerLogger.setLevel(Level.DEBUG);
         var listAppender = new ListAppender<ILoggingEvent>();
         listAppender.setContext(triggerLogger.getLoggerContext());
         listAppender.start();


### PR DESCRIPTION
## Summary

- Add structured INFO lifecycle logs to `RealtimeTrigger` so users can verify Kafka connectivity without waiting for the first record
- Logs cover: startup config (bootstrap.servers, groupId, groupType, serdes), consumer creation, topic subscription, partition assignment (CONSUMER mode via `ConsumerRebalanceListener`), first batch received (SHARE mode), wakeup on `WakeupException`, and shutdown
- Each log message includes `triggerId=` for easy grepping
- Sensitive SASL/SSL properties are never logged — only `bootstrap.servers` is extracted from the resolved properties map
- `Consume.ConsumerSubscription` gains an optional `rebalanceListener` overload so the batch `Consume.run()` path is unaffected
- `TopicPartitionsSubscription` (manual `assign`) notifies the listener immediately after assignment since Kafka's assign API never fires rebalance callbacks
- Added `ch.qos.logback:logback-classic` as a test dependency to support `ListAppender`-based log assertions

closes: https://github.com/kestra-io/plugin-kafka/issues/176

## Test plan

- [ ] `rtk test ./gradlew test` passes (excluding pre-existing `KafkaTest.invalidBrokers` failure due to French locale on this machine)
- [ ] `shouldEmitStartupAndSubscriptionLogs` asserts triggerId, bootstrap.servers, topic name, and groupType=CONSUMER appear in logs
- [ ] `shouldEmitShutdownLog` asserts "Stopping Kafka trigger" log with triggerId appears after `trigger.stop()`
- [ ] `flow()` integration test continues to pass unmodified