### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 version=1.8.1-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19
 confluentVersion=8.0.0
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m

--- a/src/main/java/io/kestra/plugin/kafka/Consume.java
+++ b/src/main/java/io/kestra/plugin/kafka/Consume.java
@@ -363,7 +363,7 @@ public class Consume extends AbstractKafkaConnection implements RunnableTask<Con
 
     private Output runWithConsumer(RunContext runContext, File tempFile) throws Exception {
         try (
-            var output = new BufferedOutputStream(new FileOutputStream(tempFile));
+            var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE);
             var consumer = this.consumer(runContext)
         ) {
             this.subscription = topicSubscription(runContext);
@@ -406,7 +406,7 @@ public class Consume extends AbstractKafkaConnection implements RunnableTask<Con
     private Output runWithShareConsumer(RunContext runContext, File tempFile) throws Exception {
         validateShareConfiguration();
         try (
-            var output = new BufferedOutputStream(new FileOutputStream(tempFile));
+            var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE);
             var consumer = this.shareConsumer(runContext)
         ) {
             shareSubscribe(runContext, consumer);

--- a/src/test/java/io/kestra/plugin/kafka/KafkaTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/KafkaTest.java
@@ -95,7 +95,7 @@ public class KafkaTest {
         String topic = "tu_" + IdUtils.create();
 
         File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
-        OutputStream output = new FileOutputStream(tempFile);
+        OutputStream output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE);
 
         for (int i = 0; i < 50; i++) {
             HashMap<Object, Object> data = new HashMap<>();
@@ -161,9 +161,10 @@ public class KafkaTest {
         Consume.Output consumeOutput = consume.run(runContext);
         assertThat(consumeOutput.getMessagesCount(), is(50));
 
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, consumeOutput.getUri())));
         List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
+        try (var inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, consumeOutput.getUri()), FileSerde.BUFFER_SIZE)) {
+            FileSerde.read(inputStream, r -> result.add((Map<String, Object>) r));
+        }
 
         assertThat(result.size(), is(50));
 
@@ -1008,8 +1009,8 @@ public class KafkaTest {
     }
 
     private static void assertOutputFile(RunContext runContext, Consume.Output consumeOutput) throws IOException {
-        InputStream is = runContext.storage().getFile(consumeOutput.getUri());
-        Flux<Map> reader = FileSerde.readAll(new BufferedReader(new InputStreamReader(is)), Map.class);
+        var is = new BufferedInputStream(runContext.storage().getFile(consumeOutput.getUri()), FileSerde.BUFFER_SIZE);
+        Flux<Map> reader = FileSerde.readAll(is, Map.class);
         Map<String, Object> result = reader.blockLast();
         Assertions.assertNotNull(result);
         Assertions.assertTrue(result.containsKey("key"));
@@ -1027,8 +1028,9 @@ public class KafkaTest {
         map.put("timestamp", Instant.now().toEpochMilli());
 
         File tempFile = File.createTempFile("consumeProduce", ".txt");
-        OutputStream output = new FileOutputStream(tempFile);
-        FileSerde.write(output, map);
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
+            FileSerde.write(output, map);
+        }
         return tempFile;
     }
 

--- a/src/test/java/io/kestra/plugin/kafka/KafkaTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/KafkaTest.java
@@ -95,26 +95,26 @@ public class KafkaTest {
         String topic = "tu_" + IdUtils.create();
 
         File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
-        OutputStream output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE);
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
+            for (int i = 0; i < 50; i++) {
+                HashMap<Object, Object> data = new HashMap<>();
+                data.put("username", "Kestra-" + i);
+                data.put("tweet", "Kestra is open source");
+                data.put("timestamp", System.currentTimeMillis() / 1000);
+                data.put("instant", ZonedDateTime.parse("2022-01-03T00:00:00+01:00").toInstant());
+                data.put("zonedDatetimeMillis", ZonedDateTime.parse("2022-01-03T00:00:00+01:00"));
+                data.put("zonedDatetimeMicros", ZonedDateTime.parse("2022-01-03T00:00:00+01:00"));
+                data.put("offsetDatetimeMillis", OffsetDateTime.parse("2022-01-03T00:00:00+01:00"));
+                data.put("offsetDatetimeMicros", OffsetDateTime.parse("2022-01-03T00:00:00+01:00"));
+                data.put("unionLogical", i < 25 ? ZonedDateTime.parse("2022-01-03T00:00:00+01:00").toInstant() : null);
 
-        for (int i = 0; i < 50; i++) {
-            HashMap<Object, Object> data = new HashMap<>();
-            data.put("username", "Kestra-" + i);
-            data.put("tweet", "Kestra is open source");
-            data.put("timestamp", System.currentTimeMillis() / 1000);
-            data.put("instant", ZonedDateTime.parse("2022-01-03T00:00:00+01:00").toInstant());
-            data.put("zonedDatetimeMillis", ZonedDateTime.parse("2022-01-03T00:00:00+01:00"));
-            data.put("zonedDatetimeMicros", ZonedDateTime.parse("2022-01-03T00:00:00+01:00"));
-            data.put("offsetDatetimeMillis", OffsetDateTime.parse("2022-01-03T00:00:00+01:00"));
-            data.put("offsetDatetimeMicros", OffsetDateTime.parse("2022-01-03T00:00:00+01:00"));
-            data.put("unionLogical", i < 25 ? ZonedDateTime.parse("2022-01-03T00:00:00+01:00").toInstant() : null);
-
-            FileSerde.write(output, ImmutableMap.builder()
-                .put("key", "key-" + i)
-                .put("value", data)
-                .put("timestamp", Instant.now().toEpochMilli())
-                .build()
-            );
+                FileSerde.write(output, ImmutableMap.builder()
+                    .put("key", "key-" + i)
+                    .put("value", data)
+                    .put("timestamp", Instant.now().toEpochMilli())
+                    .build()
+                );
+            }
         }
 
         URI uri = storageInterface.put(TenantService.MAIN_TENANT, null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));


### PR DESCRIPTION
Migrates the FileSerde reads and writes to byte streams so binary ION is not corrupted.