### PR TITLE
fix(produce): propagate async send errors instead of dropping them

### DIFF
--- a/src/main/java/io/kestra/plugin/kafka/Produce.java
+++ b/src/main/java/io/kestra/plugin/kafka/Produce.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
@@ -237,6 +238,9 @@ public class Produce extends AbstractKafkaConnection implements RunnableTask<Pro
 
         KafkaProducer<Object, Object> producer = new KafkaProducer<>(properties, keySerializer, valueSerializer);
 
+        // send() is async, broker-side failures only reach the callback. Capture the first one.
+        final AtomicReference<Exception> sendException = new AtomicReference<>();
+
         try {
             if (transactional) {
                 producer.initTransactions();
@@ -245,11 +249,26 @@ public class Produce extends AbstractKafkaConnection implements RunnableTask<Pro
 
             Integer count = Data.from(from).read(runContext)
                 .map(throwFunction(row -> {
-                    producer.send(this.producerRecord(runContext, producer, row));
+                    producer.send(this.producerRecord(runContext, producer, row), (metadata, exception) -> {
+                        if (exception != null) {
+                            sendException.compareAndSet(null, exception);
+                        }
+                    });
                     return 1;
                 }))
                 .reduce(Integer::sum)
                 .blockOptional().orElse(0);
+
+            // Drain pending sends so callbacks run, then fail the task if any send failed.
+            if (transactional) {
+                producer.commitTransaction();
+            }
+            producer.flush();
+
+            Exception exception = sendException.get();
+            if (exception != null) {
+                throw exception;
+            }
 
             runContext.metric(Counter.of("records", count));
 
@@ -257,10 +276,6 @@ public class Produce extends AbstractKafkaConnection implements RunnableTask<Pro
                 .messagesCount(count)
                 .build();
         } finally {
-            if (transactional) {
-                producer.commitTransaction();
-            }
-            producer.flush();
             producer.close();
         }
     }

--- a/src/test/java/io/kestra/plugin/kafka/KafkaTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/KafkaTest.java
@@ -1014,9 +1014,7 @@ public class KafkaTest {
         RunContext runContext = runContextFactory.of(Map.of());
         String topic = "tu_" + IdUtils.create();
 
-        // A value above the broker's message.max.bytes (~1MB default) is accepted by the client
-        // because max.request.size is raised, then rejected by the broker through the send callback.
-        // Before the fix this error was discarded and the task reported success.
+        // Too big for the broker but allowed by the client, so it fails async via the send callback.
         String oversizedValue = "x".repeat(2 * 1024 * 1024);
 
         Produce task = Produce.builder()

--- a/src/test/java/io/kestra/plugin/kafka/KafkaTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/KafkaTest.java
@@ -17,6 +17,7 @@ import jakarta.inject.Inject;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.junit.jupiter.api.Assertions;
@@ -1006,6 +1007,32 @@ public class KafkaTest {
         } finally {
             glueMock.stop();
         }
+    }
+
+    @Test
+    void onAsyncSendError_shouldFail() {
+        RunContext runContext = runContextFactory.of(Map.of());
+        String topic = "tu_" + IdUtils.create();
+
+        // A value above the broker's message.max.bytes (~1MB default) is accepted by the client
+        // because max.request.size is raised, then rejected by the broker through the send callback.
+        // Before the fix this error was discarded and the task reported success.
+        String oversizedValue = "x".repeat(2 * 1024 * 1024);
+
+        Produce task = Produce.builder()
+            .properties(Property.ofValue(Map.of(
+                "bootstrap.servers", this.bootstrap,
+                "max.request.size", "10485760",
+                "buffer.memory", "20971520"
+            )))
+            .transactional(Property.ofValue(false))
+            .keySerializer(Property.ofValue(SerdeType.STRING))
+            .valueSerializer(Property.ofValue(SerdeType.STRING))
+            .topic(Property.ofValue(topic))
+            .from(Map.of("key", "key", "value", oversizedValue))
+            .build();
+
+        assertThrows(RecordTooLargeException.class, () -> task.run(runContext));
     }
 
     private static void assertOutputFile(RunContext runContext, Consume.Output consumeOutput) throws IOException {


### PR DESCRIPTION
- closes #174 