### PR TITLE
fix(realtime-trigger): prevent busy-loop on broker unavailability by bounding poll timeout

### DIFF
--- a/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
@@ -51,6 +51,8 @@ import java.util.concurrent.atomic.AtomicReference;
         In `SHARE` mode, use `topic` with `groupId`; `topicPattern`, `partitions`, and `since` are not supported.
         Use header filters to drop unmatched records. Prefer the batch [Kafka Trigger](https://kestra.io/plugins/plugin-kafka/triggers/io.kestra.plugin.kafka.trigger) for interval-based pulls.
         Emits DEBUG logs on startup, subscription, connection confirmation, and shutdown — grep by triggerId to verify Kafka connectivity.
+        When the broker is unreachable, the trigger backs off exponentially (up to `reconnectBackoffMax`) instead of busy-looping,
+        and emits a WARN log on each backoff escalation. Use `maxReconnectAttempts` to fail fast after a configurable number of retries.
         """
 )
 @Plugin(
@@ -193,6 +195,48 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
     private Property<String> since;
 
+    @Schema(
+        title = "Filter messages by Kafka headers",
+        description = "Consume records only when all header key/value pairs match exactly (last header wins, UTF-8 comparison)"
+    )
+    @PluginProperty(group = "advanced")
+    private Property<Map<String, String>> headerFilters;
+
+    @Schema(
+        title = "Poll timeout per iteration",
+        description = """
+            Maximum time to block inside a single `consumer.poll()` call.
+            A finite value is required so the loop can detect failure spins: when a poll returns well before
+            this duration with zero records, it is treated as a failed connection and triggers backoff.
+            Defaults to PT2S. Healthy idle polls (broker reachable, topic empty) return after this duration without triggering backoff.
+            """
+    )
+    @Builder.Default
+    @PluginProperty(group = "advanced")
+    private Property<Duration> pollDuration = Property.ofValue(Duration.ofSeconds(2));
+
+    @Schema(
+        title = "Maximum backoff delay between reconnect attempts",
+        description = """
+            Caps the exponential backoff sleep applied when the broker is unreachable.
+            Backoff starts at ~1 s and doubles on each failure spin, up to this maximum.
+            Defaults to PT30S. Reset to zero as soon as a poll succeeds.
+            """
+    )
+    @Builder.Default
+    @PluginProperty(group = "advanced")
+    private Property<Duration> reconnectBackoffMax = Property.ofValue(Duration.ofSeconds(30));
+
+    @Schema(
+        title = "Maximum number of consecutive reconnect attempts before failing the trigger",
+        description = """
+            When set, the trigger calls `fluxSink.error(...)` after this many consecutive failure spins,
+            terminating the flow with an error. When absent (default), the trigger retries indefinitely.
+            """
+    )
+    @PluginProperty(group = "advanced")
+    private Property<Integer> maxReconnectAttempts;
+
     @Builder.Default
     @Getter(AccessLevel.NONE)
     private final AtomicBoolean isActive = new AtomicBoolean(true);
@@ -208,13 +252,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     @Builder.Default
     @Getter(AccessLevel.NONE)
     private final AtomicReference<ShareConsumer<Object, Object>> shareConsumer = new AtomicReference<>();
-
-    @Schema(
-        title = "Filter messages by Kafka headers",
-        description = "Consume records only when all header key/value pairs match exactly (last header wins, UTF-8 comparison)"
-    )
-    @PluginProperty(group = "advanced")
-    private Property<Map<String, String>> headerFilters;
 
     protected Consume consumeTask() {
         return Consume.builder()
@@ -258,6 +295,9 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 var rKeyDeserializer = runContext.render(this.keyDeserializer).as(SerdeType.class).orElse(SerdeType.STRING);
                 var rValueDeserializer = runContext.render(this.valueDeserializer).as(SerdeType.class).orElse(SerdeType.STRING);
                 var bootstrapServers = rProperties.get("bootstrap.servers");
+                var rPollDuration = runContext.render(this.pollDuration).as(Duration.class).orElse(Duration.ofSeconds(2));
+                var rReconnectBackoffMax = runContext.render(this.reconnectBackoffMax).as(Duration.class).orElse(Duration.ofSeconds(30));
+                var rMaxReconnectAttempts = runContext.render(this.maxReconnectAttempts).as(Integer.class).orElse(null);
 
                 logger.debug(
                     "Starting Kafka trigger triggerId={} bootstrap.servers={} groupId={} groupType={} topics={} topicPattern={} partitions={} keyDeserializer={} valueDeserializer={}",
@@ -267,9 +307,9 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 );
 
                 if (rGroupType == GroupType.SHARE) {
-                    runWithShareConsumer(task, runContext, fluxSink);
+                    runWithShareConsumer(task, runContext, fluxSink, rPollDuration, rReconnectBackoffMax, rMaxReconnectAttempts);
                 } else {
-                    runWithConsumer(task, runContext, fluxSink);
+                    runWithConsumer(task, runContext, fluxSink, rPollDuration, rReconnectBackoffMax, rMaxReconnectAttempts);
                 }
             } catch (WakeupException e) {
                 logger.debug("Kafka trigger triggerId={} woken up; stopping poll loop", this.id);
@@ -285,7 +325,10 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
     private void runWithConsumer(Consume task,
                                  RunContext runContext,
-                                 FluxSink<ConsumerRecord<Object, Object>> fluxSink) throws Exception {
+                                 FluxSink<ConsumerRecord<Object, Object>> fluxSink,
+                                 Duration pollDuration,
+                                 Duration reconnectBackoffMax,
+                                 Integer maxReconnectAttempts) throws Exception {
         Logger logger = runContext.logger();
         try (KafkaConsumer<Object, Object> consumer = task.consumer(runContext)) {
             this.consumer.set(consumer);
@@ -316,17 +359,21 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 this.partitions
             );
 
-            runPollingLoop(() -> {
-                var records = consumer.poll(Duration.ofMillis(Long.MAX_VALUE));
+            runPollingLoop(logger, fluxSink, pollDuration, reconnectBackoffMax, maxReconnectAttempts, () -> {
+                var records = consumer.poll(pollDuration);
                 task.processConsumerRecords(runContext, records, fluxSink::next);
                 consumer.commitSync();
+                return records.count();
             });
         }
     }
 
     private void runWithShareConsumer(Consume task,
                                       RunContext runContext,
-                                      FluxSink<ConsumerRecord<Object, Object>> fluxSink) throws Exception {
+                                      FluxSink<ConsumerRecord<Object, Object>> fluxSink,
+                                      Duration pollDuration,
+                                      Duration reconnectBackoffMax,
+                                      Integer maxReconnectAttempts) throws Exception {
         Logger logger = runContext.logger();
         task.validateShareConfiguration();
         try (var consumer = task.shareConsumer(runContext)) {
@@ -343,35 +390,122 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             );
 
             var firstShareBatch = new AtomicBoolean(false);
-            runPollingLoop(() -> {
-                var records = consumer.poll(Duration.ofMillis(Long.MAX_VALUE));
+            runPollingLoop(logger, fluxSink, pollDuration, reconnectBackoffMax, maxReconnectAttempts, () -> {
+                var records = consumer.poll(pollDuration);
                 // compareAndSet flips the flag and returns true only on the first non-empty batch, so this logs once
                 if (!records.isEmpty() && firstShareBatch.compareAndSet(false, true)) {
                     logger.debug("Kafka SHARE connection confirmed for triggerId={}: first batch received ({} records)", this.id, records.count());
                 }
                 task.processShareConsumerRecords(runContext, consumer, records, fluxSink::next);
                 consumer.commitSync();
+                return records.count();
             });
         }
     }
 
-    private void runPollingLoop(PollAction pollAction) throws Exception {
+    /**
+     * Runs the poll loop with exponential backoff on failure spins.
+     *
+     * A poll iteration is a "failure spin" when it either throws a connection/timeout exception
+     * OR it returns near-instantly (well under pollDuration) with zero records. This distinguishes
+     * a healthy idle topic (blocks ~pollDuration, returns empty) from a dead broker (returns instantly).
+     * Backoff resets to zero as soon as any poll delivers records or blocks normally.
+     */
+    private void runPollingLoop(Logger logger,
+                                FluxSink<ConsumerRecord<Object, Object>> fluxSink,
+                                Duration pollDuration,
+                                Duration reconnectBackoffMax,
+                                Integer maxReconnectAttempts,
+                                PollAction pollAction) throws Exception {
+        // idle threshold: a poll blocking for at least 80% of pollDuration is considered healthy
+        final long idleThresholdMs = (long) (pollDuration.toMillis() * 0.8);
+        final long backoffCapMs = reconnectBackoffMax.toMillis();
+        long currentBackoffMs = 0;
+        int failureSpins = 0;
+        boolean inRetryState = false;
+
         while (isActive.get()) {
+            long pollStart = System.currentTimeMillis();
+            int recordCount = 0;
+            boolean pollFailed = false;
+
             try {
-                pollAction.run();
+                recordCount = pollAction.run();
             } catch (org.apache.kafka.common.errors.InterruptException e) {
-                // ignore, this case is handle by next lines
+                // ignore, handled by isInterrupted check below
+            } catch (Exception e) {
+                pollFailed = true;
+                // log only on first failure or when backoff escalates to avoid spam
+                if (!inRetryState) {
+                    logger.warn(
+                        "Kafka trigger triggerId={} broker unreachable ({}); will retry with backoff",
+                        this.id, e.getMessage()
+                    );
+                }
             }
-            // Check if the current thread has been interrupted before next poll.
+
             if (Thread.currentThread().isInterrupted()) {
-                isActive.set(false); // proactively stop polling
+                isActive.set(false);
+                break;
+            }
+
+            long elapsed = System.currentTimeMillis() - pollStart;
+
+            // detect a failure spin: exception OR near-instant empty return
+            boolean isFailureSpin = pollFailed || (recordCount == 0 && elapsed < idleThresholdMs);
+
+            if (isFailureSpin) {
+                failureSpins++;
+
+                if (maxReconnectAttempts != null && failureSpins > maxReconnectAttempts) {
+                    var msg = String.format(
+                        "Kafka trigger triggerId=%s exceeded maxReconnectAttempts=%d; failing trigger",
+                        this.id, maxReconnectAttempts
+                    );
+                    logger.error(msg);
+                    fluxSink.error(new RuntimeException(msg));
+                    isActive.set(false);
+                    break;
+                }
+
+                // exponential backoff: 1s → 2s → 4s → … → cap
+                long nextBackoffMs = currentBackoffMs == 0
+                    ? 1_000L
+                    : Math.min(currentBackoffMs * 2, backoffCapMs);
+
+                if (nextBackoffMs != currentBackoffMs || !inRetryState) {
+                    logger.warn(
+                        "Kafka trigger triggerId={} retrying (attempt #{}) after {}ms backoff",
+                        this.id, failureSpins, nextBackoffMs
+                    );
+                }
+
+                currentBackoffMs = nextBackoffMs;
+                inRetryState = true;
+
+                // interruptible sleep — wakeup()/stop()/kill() break out immediately
+                try {
+                    Thread.sleep(currentBackoffMs);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    isActive.set(false);
+                    break;
+                }
+            } else {
+                // successful poll: reset backoff
+                if (inRetryState) {
+                    logger.debug("Kafka trigger triggerId={} reconnected; resetting backoff", this.id);
+                }
+                currentBackoffMs = 0;
+                failureSpins = 0;
+                inRetryState = false;
             }
         }
     }
 
     @FunctionalInterface
     private interface PollAction {
-        void run() throws Exception;
+        int run() throws Exception;
     }
 
     /**

--- a/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
@@ -363,11 +363,10 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 this.partitions
             );
 
-            runPollingLoop(logger, fluxSink, pollDuration, reconnectBackoffMax, maxReconnectAttempts, () -> {
+            runPollingLoop(logger, fluxSink, reconnectBackoffMax, maxReconnectAttempts, () -> {
                 var records = consumer.poll(pollDuration);
                 task.processConsumerRecords(runContext, records, fluxSink::next);
                 consumer.commitSync();
-                return records.count();
             });
         }
     }
@@ -394,7 +393,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             );
 
             var firstShareBatch = new AtomicBoolean(false);
-            runPollingLoop(logger, fluxSink, pollDuration, reconnectBackoffMax, maxReconnectAttempts, () -> {
+            runPollingLoop(logger, fluxSink, reconnectBackoffMax, maxReconnectAttempts, () -> {
                 var records = consumer.poll(pollDuration);
                 // compareAndSet flips the flag and returns true only on the first non-empty batch, so this logs once
                 if (!records.isEmpty() && firstShareBatch.compareAndSet(false, true)) {
@@ -402,7 +401,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 }
                 task.processShareConsumerRecords(runContext, consumer, records, fluxSink::next);
                 consumer.commitSync();
-                return records.count();
             });
         }
     }
@@ -410,22 +408,18 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     /**
      * Runs the poll loop with exponential backoff when the broker is unreachable.
      *
-     * A poll iteration is a "failure spin" when it throws any exception other than InterruptException,
-     * OR when it returns in well under pollDuration with zero records (connection-refused / instant fail).
-     * The elapsed-time check catches fast-fail cases (e.g. connection refused) that Kafka surfances
-     * as an empty result rather than an exception. On a healthy idle topic the poll blocks for
-     * approximately the full pollDuration, so this heuristic does not false-trigger.
-     * Backoff resets to zero as soon as a poll delivers records or blocks for the full duration.
+     * A poll iteration is a "failure spin" when it throws any exception other than InterruptException.
+     * When Kafka cannot connect to any broker (connection refused, TLS error, invalid protocol response,
+     * etc.) it will throw after its internal retry window, which is controlled by `request.timeout.ms`.
+     * On a failure spin the loop sleeps with exponential backoff before the next attempt.
+     * Backoff resets to zero as soon as a poll succeeds without throwing.
      * The backoff sleep is interruptible so stop()/kill() terminate promptly.
      */
     private void runPollingLoop(Logger logger,
                                 FluxSink<ConsumerRecord<Object, Object>> fluxSink,
-                                Duration pollDuration,
                                 Duration reconnectBackoffMax,
                                 Integer maxReconnectAttempts,
                                 PollAction pollAction) throws Exception {
-        // polls that return in under 20% of pollDuration with 0 records are treated as failure spins
-        final long idleThresholdMs = pollDuration.toMillis() / 5;
         final long backoffCapMs = reconnectBackoffMax.toMillis();
         long currentBackoffMs = 0;
         int failureSpins = 0;
@@ -434,12 +428,10 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         pollThread.set(Thread.currentThread());
 
         while (isActive.get()) {
-            long pollStart = System.currentTimeMillis();
-            int recordCount = 0;
             boolean pollFailed = false;
 
             try {
-                recordCount = pollAction.run();
+                pollAction.run();
             } catch (org.apache.kafka.common.errors.InterruptException e) {
                 // ignore, handled by isInterrupted check below
             } catch (Exception e) {
@@ -457,11 +449,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 break;
             }
 
-            long elapsed = System.currentTimeMillis() - pollStart;
-            // detect a failure spin: exception OR near-instant empty return (< 20% of pollDuration)
-            boolean isFailureSpin = pollFailed || (recordCount == 0 && elapsed < idleThresholdMs);
-
-            if (isFailureSpin) {
+            if (pollFailed) {
                 failureSpins++;
 
                 if (maxReconnectAttempts != null && failureSpins > maxReconnectAttempts) {
@@ -511,7 +499,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
     @FunctionalInterface
     private interface PollAction {
-        int run() throws Exception;
+        void run() throws Exception;
     }
 
     /**

--- a/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
@@ -51,8 +51,8 @@ import java.util.concurrent.atomic.AtomicReference;
         In `SHARE` mode, use `topic` with `groupId`; `topicPattern`, `partitions`, and `since` are not supported.
         Use header filters to drop unmatched records. Prefer the batch [Kafka Trigger](https://kestra.io/plugins/plugin-kafka/triggers/io.kestra.plugin.kafka.trigger) for interval-based pulls.
         Emits DEBUG logs on startup, subscription, connection confirmation, and shutdown — grep by triggerId to verify Kafka connectivity.
-        When the broker is unreachable, the trigger backs off exponentially (up to `reconnectBackoffMax`) instead of busy-looping,
-        and emits a WARN log on each backoff escalation. Use `maxReconnectAttempts` to fail fast after a configurable number of retries.
+        When the broker is unreachable, the trigger backs off exponentially instead of busy-looping,
+        and emits a WARN log on each backoff escalation.
         """
 )
 @Plugin(
@@ -140,6 +140,20 @@ import java.util.concurrent.atomic.AtomicReference;
     }
 )
 public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerInterface, TriggerOutput<Message>, KafkaConnectionInterface, KafkaConsumerInterface {
+
+    // How long a single consumer.poll() call may block. A finite value lets the loop detect
+    // failure spins: a poll that returns in well under this duration with zero records indicates
+    // the broker is unreachable (connection refused, timeout, etc.).
+    private static final Duration POLL_DURATION = Duration.ofSeconds(2);
+
+    // Exponential backoff parameters (internal, not user-configurable).
+    private static final long BACKOFF_INITIAL_MS = 1_000L;
+    private static final long BACKOFF_CAP_MS = 30_000L;
+
+    // A poll that completes in less than this fraction of POLL_DURATION with zero records is
+    // treated as a failure spin (broker unreachable, returned immediately).
+    private static final double FAST_EMPTY_POLL_THRESHOLD = 0.5;
+
     private Property<Map<String, String>> properties;
 
     @Builder.Default
@@ -201,41 +215,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     )
     @PluginProperty(group = "advanced")
     private Property<Map<String, String>> headerFilters;
-
-    @Schema(
-        title = "Poll timeout per iteration",
-        description = """
-            Maximum time to block inside a single `consumer.poll()` call.
-            A finite value is required so the loop can detect failure spins: when a poll returns well before
-            this duration with zero records, it is treated as a failed connection and triggers backoff.
-            Defaults to PT2S. Healthy idle polls (broker reachable, topic empty) return after this duration without triggering backoff.
-            """
-    )
-    @Builder.Default
-    @PluginProperty(group = "advanced")
-    private Property<Duration> pollDuration = Property.ofValue(Duration.ofSeconds(2));
-
-    @Schema(
-        title = "Maximum backoff delay between reconnect attempts",
-        description = """
-            Caps the exponential backoff sleep applied when the broker is unreachable.
-            Backoff starts at ~1 s and doubles on each failure spin, up to this maximum.
-            Defaults to PT30S. Reset to zero as soon as a poll succeeds.
-            """
-    )
-    @Builder.Default
-    @PluginProperty(group = "advanced")
-    private Property<Duration> reconnectBackoffMax = Property.ofValue(Duration.ofSeconds(30));
-
-    @Schema(
-        title = "Maximum number of consecutive reconnect attempts before failing the trigger",
-        description = """
-            When set, the trigger calls `fluxSink.error(...)` after this many consecutive failure spins,
-            terminating the flow with an error. When absent (default), the trigger retries indefinitely.
-            """
-    )
-    @PluginProperty(group = "advanced")
-    private Property<Integer> maxReconnectAttempts;
 
     @Builder.Default
     @Getter(AccessLevel.NONE)
@@ -299,9 +278,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 var rKeyDeserializer = runContext.render(this.keyDeserializer).as(SerdeType.class).orElse(SerdeType.STRING);
                 var rValueDeserializer = runContext.render(this.valueDeserializer).as(SerdeType.class).orElse(SerdeType.STRING);
                 var bootstrapServers = rProperties.get("bootstrap.servers");
-                var rPollDuration = runContext.render(this.pollDuration).as(Duration.class).orElse(Duration.ofSeconds(2));
-                var rReconnectBackoffMax = runContext.render(this.reconnectBackoffMax).as(Duration.class).orElse(Duration.ofSeconds(30));
-                var rMaxReconnectAttempts = runContext.render(this.maxReconnectAttempts).as(Integer.class).orElse(null);
 
                 logger.debug(
                     "Starting Kafka trigger triggerId={} bootstrap.servers={} groupId={} groupType={} topics={} topicPattern={} partitions={} keyDeserializer={} valueDeserializer={}",
@@ -311,9 +287,9 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 );
 
                 if (rGroupType == GroupType.SHARE) {
-                    runWithShareConsumer(task, runContext, fluxSink, rPollDuration, rReconnectBackoffMax, rMaxReconnectAttempts);
+                    runWithShareConsumer(task, runContext, fluxSink);
                 } else {
-                    runWithConsumer(task, runContext, fluxSink, rPollDuration, rReconnectBackoffMax, rMaxReconnectAttempts);
+                    runWithConsumer(task, runContext, fluxSink);
                 }
             } catch (WakeupException e) {
                 logger.debug("Kafka trigger triggerId={} woken up; stopping poll loop", this.id);
@@ -329,10 +305,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
     private void runWithConsumer(Consume task,
                                  RunContext runContext,
-                                 FluxSink<ConsumerRecord<Object, Object>> fluxSink,
-                                 Duration pollDuration,
-                                 Duration reconnectBackoffMax,
-                                 Integer maxReconnectAttempts) throws Exception {
+                                 FluxSink<ConsumerRecord<Object, Object>> fluxSink) throws Exception {
         Logger logger = runContext.logger();
         try (KafkaConsumer<Object, Object> consumer = task.consumer(runContext)) {
             this.consumer.set(consumer);
@@ -363,20 +336,20 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 this.partitions
             );
 
-            runPollingLoop(logger, fluxSink, reconnectBackoffMax, maxReconnectAttempts, () -> {
-                var records = consumer.poll(pollDuration);
+            runPollingLoop(logger, fluxSink, () -> {
+                long start = System.nanoTime();
+                var records = consumer.poll(POLL_DURATION);
+                long elapsedMs = (System.nanoTime() - start) / 1_000_000;
                 task.processConsumerRecords(runContext, records, fluxSink::next);
                 consumer.commitSync();
+                return records.isEmpty() ? (isFailureSpin(elapsedMs) ? -1 : 0) : records.count();
             });
         }
     }
 
     private void runWithShareConsumer(Consume task,
                                       RunContext runContext,
-                                      FluxSink<ConsumerRecord<Object, Object>> fluxSink,
-                                      Duration pollDuration,
-                                      Duration reconnectBackoffMax,
-                                      Integer maxReconnectAttempts) throws Exception {
+                                      FluxSink<ConsumerRecord<Object, Object>> fluxSink) throws Exception {
         Logger logger = runContext.logger();
         task.validateShareConfiguration();
         try (var consumer = task.shareConsumer(runContext)) {
@@ -393,34 +366,47 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             );
 
             var firstShareBatch = new AtomicBoolean(false);
-            runPollingLoop(logger, fluxSink, reconnectBackoffMax, maxReconnectAttempts, () -> {
-                var records = consumer.poll(pollDuration);
+            runPollingLoop(logger, fluxSink, () -> {
+                long start = System.nanoTime();
+                var records = consumer.poll(POLL_DURATION);
+                long elapsedMs = (System.nanoTime() - start) / 1_000_000;
                 // compareAndSet flips the flag and returns true only on the first non-empty batch, so this logs once
                 if (!records.isEmpty() && firstShareBatch.compareAndSet(false, true)) {
                     logger.debug("Kafka SHARE connection confirmed for triggerId={}: first batch received ({} records)", this.id, records.count());
                 }
                 task.processShareConsumerRecords(runContext, consumer, records, fluxSink::next);
                 consumer.commitSync();
+                return records.isEmpty() ? (isFailureSpin(elapsedMs) ? -1 : 0) : records.count();
             });
         }
     }
 
     /**
+     * Returns true when a poll that returned zero records completed suspiciously fast,
+     * indicating the broker is unreachable rather than the topic simply being idle.
+     * A healthy idle poll blocks for approximately POLL_DURATION; a refused-connection
+     * or immediate timeout returns in a tiny fraction of that.
+     */
+    private static boolean isFailureSpin(long elapsedMs) {
+        return elapsedMs < (long) (POLL_DURATION.toMillis() * FAST_EMPTY_POLL_THRESHOLD);
+    }
+
+    /**
      * Runs the poll loop with exponential backoff when the broker is unreachable.
      *
-     * A poll iteration is a "failure spin" when it throws any exception other than InterruptException.
-     * When Kafka cannot connect to any broker (connection refused, TLS error, invalid protocol response,
-     * etc.) it will throw after its internal retry window, which is controlled by `request.timeout.ms`.
-     * On a failure spin the loop sleeps with exponential backoff before the next attempt.
-     * Backoff resets to zero as soon as a poll succeeds without throwing.
+     * A poll iteration is a "failure spin" when it either:
+     * - throws any exception other than InterruptException, or
+     * - returns zero records in well under POLL_DURATION (fast-empty heuristic).
+     *
+     * When Kafka cannot connect to any broker (connection refused, TLS error, invalid protocol
+     * response, etc.) it will throw after its internal retry window, or return immediately with
+     * zero records. On a failure spin the loop sleeps with exponential backoff before the next
+     * attempt. Backoff resets to zero as soon as a poll succeeds or blocks normally (idle topic).
      * The backoff sleep is interruptible so stop()/kill() terminate promptly.
      */
     private void runPollingLoop(Logger logger,
                                 FluxSink<ConsumerRecord<Object, Object>> fluxSink,
-                                Duration reconnectBackoffMax,
-                                Integer maxReconnectAttempts,
                                 PollAction pollAction) throws Exception {
-        final long backoffCapMs = reconnectBackoffMax.toMillis();
         long currentBackoffMs = 0;
         int failureSpins = 0;
         boolean inRetryState = false;
@@ -430,8 +416,19 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         while (isActive.get()) {
             boolean pollFailed = false;
 
+            int recordCount;
             try {
-                pollAction.run();
+                recordCount = pollAction.run();
+                // negative sentinel: fast-empty heuristic fired (broker unreachable, no exception)
+                if (recordCount < 0) {
+                    pollFailed = true;
+                    if (!inRetryState) {
+                        logger.warn(
+                            "Kafka trigger triggerId={} poll returned immediately with no records; broker may be unreachable — will retry with backoff",
+                            this.id
+                        );
+                    }
+                }
             } catch (org.apache.kafka.common.errors.InterruptException e) {
                 // ignore, handled by isInterrupted check below
             } catch (Exception e) {
@@ -452,21 +449,9 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             if (pollFailed) {
                 failureSpins++;
 
-                if (maxReconnectAttempts != null && failureSpins > maxReconnectAttempts) {
-                    var msg = String.format(
-                        "Kafka trigger triggerId=%s exceeded maxReconnectAttempts=%d; failing trigger",
-                        this.id, maxReconnectAttempts
-                    );
-                    logger.error(msg);
-                    fluxSink.error(new RuntimeException(msg));
-                    isActive.set(false);
-                    break;
-                }
-
-                // exponential backoff: 1s → 2s → 4s → … → cap
                 long nextBackoffMs = currentBackoffMs == 0
-                    ? 1_000L
-                    : Math.min(currentBackoffMs * 2, backoffCapMs);
+                    ? BACKOFF_INITIAL_MS
+                    : Math.min(currentBackoffMs * 2, BACKOFF_CAP_MS);
 
                 if (nextBackoffMs != currentBackoffMs || !inRetryState) {
                     logger.warn(
@@ -499,7 +484,12 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
     @FunctionalInterface
     private interface PollAction {
-        void run() throws Exception;
+        /**
+         * Executes one poll cycle and returns the number of records processed.
+         * Returns a negative value when the poll completed suspiciously fast with zero records
+         * (fast-empty heuristic, indicating broker unreachability without an exception).
+         */
+        int run() throws Exception;
     }
 
     /**

--- a/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
@@ -51,8 +51,6 @@ import java.util.concurrent.atomic.AtomicReference;
         In `SHARE` mode, use `topic` with `groupId`; `topicPattern`, `partitions`, and `since` are not supported.
         Use header filters to drop unmatched records. Prefer the batch [Kafka Trigger](https://kestra.io/plugins/plugin-kafka/triggers/io.kestra.plugin.kafka.trigger) for interval-based pulls.
         Emits DEBUG logs on startup, subscription, connection confirmation, and shutdown — grep by triggerId to verify Kafka connectivity.
-        When the broker is unreachable, the trigger backs off exponentially instead of busy-looping,
-        and emits a WARN log on each backoff escalation.
         """
 )
 @Plugin(
@@ -141,18 +139,10 @@ import java.util.concurrent.atomic.AtomicReference;
 )
 public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerInterface, TriggerOutput<Message>, KafkaConnectionInterface, KafkaConsumerInterface {
 
-    // How long a single consumer.poll() call may block. A finite value lets the loop detect
-    // failure spins: a poll that returns in well under this duration with zero records indicates
-    // the broker is unreachable (connection refused, timeout, etc.).
+    // How long a single consumer.poll() call may block. A finite value prevents the poll loop
+    // from busy-spinning when the broker is unreachable: poll() blocks for at most this duration
+    // before the loop re-checks isActive and polls again. (Long.MAX_VALUE here would spin.)
     private static final Duration POLL_DURATION = Duration.ofSeconds(2);
-
-    // Exponential backoff parameters (internal, not user-configurable).
-    private static final long BACKOFF_INITIAL_MS = 1_000L;
-    private static final long BACKOFF_CAP_MS = 30_000L;
-
-    // A poll that completes in less than this fraction of POLL_DURATION with zero records is
-    // treated as a failure spin (broker unreachable, returned immediately).
-    private static final double FAST_EMPTY_POLL_THRESHOLD = 0.5;
 
     private Property<Map<String, String>> properties;
 
@@ -224,10 +214,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     @Builder.Default
     @Getter(AccessLevel.NONE)
     private final AtomicReference<ShareConsumer<Object, Object>> shareConsumer = new AtomicReference<>();
-
-    @Builder.Default
-    @Getter(AccessLevel.NONE)
-    private final AtomicReference<Thread> pollThread = new AtomicReference<>();
 
     @Schema(
         title = "Filter messages by Kafka headers",
@@ -336,13 +322,10 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 this.partitions
             );
 
-            runPollingLoop(logger, fluxSink, () -> {
-                long start = System.nanoTime();
+            runPollingLoop(() -> {
                 var records = consumer.poll(POLL_DURATION);
-                long elapsedMs = (System.nanoTime() - start) / 1_000_000;
                 task.processConsumerRecords(runContext, records, fluxSink::next);
                 consumer.commitSync();
-                return records.isEmpty() ? (isFailureSpin(elapsedMs) ? -1 : 0) : records.count();
             });
         }
     }
@@ -366,130 +349,35 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             );
 
             var firstShareBatch = new AtomicBoolean(false);
-            runPollingLoop(logger, fluxSink, () -> {
-                long start = System.nanoTime();
+            runPollingLoop(() -> {
                 var records = consumer.poll(POLL_DURATION);
-                long elapsedMs = (System.nanoTime() - start) / 1_000_000;
                 // compareAndSet flips the flag and returns true only on the first non-empty batch, so this logs once
                 if (!records.isEmpty() && firstShareBatch.compareAndSet(false, true)) {
                     logger.debug("Kafka SHARE connection confirmed for triggerId={}: first batch received ({} records)", this.id, records.count());
                 }
                 task.processShareConsumerRecords(runContext, consumer, records, fluxSink::next);
                 consumer.commitSync();
-                return records.isEmpty() ? (isFailureSpin(elapsedMs) ? -1 : 0) : records.count();
             });
         }
     }
 
-    /**
-     * Returns true when a poll that returned zero records completed suspiciously fast,
-     * indicating the broker is unreachable rather than the topic simply being idle.
-     * A healthy idle poll blocks for approximately POLL_DURATION; a refused-connection
-     * or immediate timeout returns in a tiny fraction of that.
-     */
-    private static boolean isFailureSpin(long elapsedMs) {
-        return elapsedMs < (long) (POLL_DURATION.toMillis() * FAST_EMPTY_POLL_THRESHOLD);
-    }
-
-    /**
-     * Runs the poll loop with exponential backoff when the broker is unreachable.
-     *
-     * A poll iteration is a "failure spin" when it either:
-     * - throws any exception other than InterruptException, or
-     * - returns zero records in well under POLL_DURATION (fast-empty heuristic).
-     *
-     * When Kafka cannot connect to any broker (connection refused, TLS error, invalid protocol
-     * response, etc.) it will throw after its internal retry window, or return immediately with
-     * zero records. On a failure spin the loop sleeps with exponential backoff before the next
-     * attempt. Backoff resets to zero as soon as a poll succeeds or blocks normally (idle topic).
-     * The backoff sleep is interruptible so stop()/kill() terminate promptly.
-     */
-    private void runPollingLoop(Logger logger,
-                                FluxSink<ConsumerRecord<Object, Object>> fluxSink,
-                                PollAction pollAction) throws Exception {
-        long currentBackoffMs = 0;
-        int failureSpins = 0;
-        boolean inRetryState = false;
-
-        pollThread.set(Thread.currentThread());
-
+    private void runPollingLoop(PollAction pollAction) throws Exception {
         while (isActive.get()) {
-            boolean pollFailed = false;
-
-            int recordCount;
             try {
-                recordCount = pollAction.run();
-                // negative sentinel: fast-empty heuristic fired (broker unreachable, no exception)
-                if (recordCount < 0) {
-                    pollFailed = true;
-                    if (!inRetryState) {
-                        logger.warn(
-                            "Kafka trigger triggerId={} poll returned immediately with no records; broker may be unreachable — will retry with backoff",
-                            this.id
-                        );
-                    }
-                }
+                pollAction.run();
             } catch (org.apache.kafka.common.errors.InterruptException e) {
-                // ignore, handled by isInterrupted check below
-            } catch (Exception e) {
-                pollFailed = true;
-                if (!inRetryState) {
-                    logger.warn(
-                        "Kafka trigger triggerId={} broker unreachable ({}); will retry with backoff",
-                        this.id, e.getMessage()
-                    );
-                }
+                // ignore, this case is handle by next lines
             }
-
+            // Check if the current thread has been interrupted before next poll.
             if (Thread.currentThread().isInterrupted()) {
-                isActive.set(false);
-                break;
-            }
-
-            if (pollFailed) {
-                failureSpins++;
-
-                long nextBackoffMs = currentBackoffMs == 0
-                    ? BACKOFF_INITIAL_MS
-                    : Math.min(currentBackoffMs * 2, BACKOFF_CAP_MS);
-
-                if (nextBackoffMs != currentBackoffMs || !inRetryState) {
-                    logger.warn(
-                        "Kafka trigger triggerId={} retrying (attempt #{}) after {}ms backoff",
-                        this.id, failureSpins, nextBackoffMs
-                    );
-                }
-
-                currentBackoffMs = nextBackoffMs;
-                inRetryState = true;
-
-                // interruptible sleep — wakeup()/stop()/kill() break out immediately
-                try {
-                    Thread.sleep(currentBackoffMs);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    isActive.set(false);
-                    break;
-                }
-            } else {
-                if (inRetryState) {
-                    logger.debug("Kafka trigger triggerId={} reconnected; resetting backoff", this.id);
-                }
-                currentBackoffMs = 0;
-                failureSpins = 0;
-                inRetryState = false;
+                isActive.set(false); // proactively stop polling
             }
         }
     }
 
     @FunctionalInterface
     private interface PollAction {
-        /**
-         * Executes one poll cycle and returns the number of records processed.
-         * Returns a negative value when the poll completed suspiciously fast with zero records
-         * (fast-empty heuristic, indicating broker unreachability without an exception).
-         */
-        int run() throws Exception;
+        void run() throws Exception;
     }
 
     /**
@@ -520,8 +408,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         var hasConsumer = consumer.get() != null || shareConsumer.get() != null;
         Optional.ofNullable(consumer.get()).ifPresent(Consumer::wakeup);
         Optional.ofNullable(shareConsumer.get()).ifPresent(ShareConsumer::wakeup);
-        // interrupt the poll thread so that backoff sleeps wake up immediately
-        Optional.ofNullable(pollThread.get()).ifPresent(Thread::interrupt);
 
         if (wait && hasConsumer) {
             try {

--- a/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
@@ -209,13 +209,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
 
     private Property<String> since;
 
-    @Schema(
-        title = "Filter messages by Kafka headers",
-        description = "Consume records only when all header key/value pairs match exactly (last header wins, UTF-8 comparison)"
-    )
-    @PluginProperty(group = "advanced")
-    private Property<Map<String, String>> headerFilters;
-
     @Builder.Default
     @Getter(AccessLevel.NONE)
     private final AtomicBoolean isActive = new AtomicBoolean(true);
@@ -235,6 +228,13 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     @Builder.Default
     @Getter(AccessLevel.NONE)
     private final AtomicReference<Thread> pollThread = new AtomicReference<>();
+
+    @Schema(
+        title = "Filter messages by Kafka headers",
+        description = "Consume records only when all header key/value pairs match exactly (last header wins, UTF-8 comparison)"
+    )
+    @PluginProperty(group = "advanced")
+    private Property<Map<String, String>> headerFilters;
 
     protected Consume consumeTask() {
         return Consume.builder()

--- a/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/kafka/RealtimeTrigger.java
@@ -253,6 +253,10 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     @Getter(AccessLevel.NONE)
     private final AtomicReference<ShareConsumer<Object, Object>> shareConsumer = new AtomicReference<>();
 
+    @Builder.Default
+    @Getter(AccessLevel.NONE)
+    private final AtomicReference<Thread> pollThread = new AtomicReference<>();
+
     protected Consume consumeTask() {
         return Consume.builder()
             .id(this.id)
@@ -404,12 +408,15 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     }
 
     /**
-     * Runs the poll loop with exponential backoff on failure spins.
+     * Runs the poll loop with exponential backoff when the broker is unreachable.
      *
-     * A poll iteration is a "failure spin" when it either throws a connection/timeout exception
-     * OR it returns near-instantly (well under pollDuration) with zero records. This distinguishes
-     * a healthy idle topic (blocks ~pollDuration, returns empty) from a dead broker (returns instantly).
-     * Backoff resets to zero as soon as any poll delivers records or blocks normally.
+     * A poll iteration is a "failure spin" when it throws any exception other than InterruptException,
+     * OR when it returns in well under pollDuration with zero records (connection-refused / instant fail).
+     * The elapsed-time check catches fast-fail cases (e.g. connection refused) that Kafka surfances
+     * as an empty result rather than an exception. On a healthy idle topic the poll blocks for
+     * approximately the full pollDuration, so this heuristic does not false-trigger.
+     * Backoff resets to zero as soon as a poll delivers records or blocks for the full duration.
+     * The backoff sleep is interruptible so stop()/kill() terminate promptly.
      */
     private void runPollingLoop(Logger logger,
                                 FluxSink<ConsumerRecord<Object, Object>> fluxSink,
@@ -417,12 +424,14 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                                 Duration reconnectBackoffMax,
                                 Integer maxReconnectAttempts,
                                 PollAction pollAction) throws Exception {
-        // idle threshold: a poll blocking for at least 80% of pollDuration is considered healthy
-        final long idleThresholdMs = (long) (pollDuration.toMillis() * 0.8);
+        // polls that return in under 20% of pollDuration with 0 records are treated as failure spins
+        final long idleThresholdMs = pollDuration.toMillis() / 5;
         final long backoffCapMs = reconnectBackoffMax.toMillis();
         long currentBackoffMs = 0;
         int failureSpins = 0;
         boolean inRetryState = false;
+
+        pollThread.set(Thread.currentThread());
 
         while (isActive.get()) {
             long pollStart = System.currentTimeMillis();
@@ -435,7 +444,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                 // ignore, handled by isInterrupted check below
             } catch (Exception e) {
                 pollFailed = true;
-                // log only on first failure or when backoff escalates to avoid spam
                 if (!inRetryState) {
                     logger.warn(
                         "Kafka trigger triggerId={} broker unreachable ({}); will retry with backoff",
@@ -450,8 +458,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
             }
 
             long elapsed = System.currentTimeMillis() - pollStart;
-
-            // detect a failure spin: exception OR near-instant empty return
+            // detect a failure spin: exception OR near-instant empty return (< 20% of pollDuration)
             boolean isFailureSpin = pollFailed || (recordCount == 0 && elapsed < idleThresholdMs);
 
             if (isFailureSpin) {
@@ -492,7 +499,6 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
                     break;
                 }
             } else {
-                // successful poll: reset backoff
                 if (inRetryState) {
                     logger.debug("Kafka trigger triggerId={} reconnected; resetting backoff", this.id);
                 }
@@ -536,6 +542,8 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         var hasConsumer = consumer.get() != null || shareConsumer.get() != null;
         Optional.ofNullable(consumer.get()).ifPresent(Consumer::wakeup);
         Optional.ofNullable(shareConsumer.get()).ifPresent(ShareConsumer::wakeup);
+        // interrupt the poll thread so that backoff sleeps wake up immediately
+        Optional.ofNullable(pollThread.get()).ifPresent(Thread::interrupt);
 
         if (wait && hasConsumer) {
             try {

--- a/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
@@ -30,6 +30,7 @@ import reactor.core.scheduler.Schedulers;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -238,21 +239,24 @@ class RealtimeTriggerTest {
     }
 
     /**
-     * Starts a server socket that accepts connections but never speaks the Kafka protocol.
-     * Kafka will connect successfully but get garbage/no data, causing it to throw exceptions
-     * during poll() regardless of network filtering (firewall/iptables). The caller is responsible
-     * for closing the returned socket after the test.
+     * Starts a server socket that accepts connections and sends a garbage payload before closing.
+     * This causes Kafka's network layer to fail the protocol handshake and throw an exception
+     * during poll() rather than silently returning empty (which happens with plain EOF).
+     * The caller is responsible for closing the returned socket after the test.
      */
     private static ServerSocket startNonKafkaServer() throws IOException {
         var server = new ServerSocket(0);
         var executor = Executors.newSingleThreadExecutor();
-        // accept connections in background and immediately close them so Kafka gets EOF
         executor.submit(() -> {
             while (!server.isClosed()) {
                 try {
-                    server.accept().close();
+                    var client = server.accept();
+                    // send garbage to break the Kafka protocol handshake, then close
+                    client.getOutputStream().write(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+                    client.getOutputStream().flush();
+                    client.close();
                 } catch (IOException ignored) {
-                    // server closed — stop accepting
+                    // server closed or client error — continue
                 }
             }
         });
@@ -310,7 +314,8 @@ class RealtimeTriggerTest {
     void shouldFailAfterMaxReconnectAttempts() throws Exception {
         var triggerId = IdUtils.create();
 
-        // Use a server that accepts-and-closes connections; Kafka gets EOF and throws
+        // Use SSL with no valid keystore to force Kafka to throw AuthenticationException / SSLException
+        // during every poll attempt. This guarantees exception-based failure spins regardless of network.
         try (var fakeServer = startNonKafkaServer()) {
             var trigger = RealtimeTrigger.builder()
                 .id(triggerId)
@@ -319,13 +324,15 @@ class RealtimeTriggerTest {
                 .groupId(Property.ofValue("test-group-" + IdUtils.create()))
                 .properties(Property.ofValue(Map.of(
                     "bootstrap.servers", "localhost:" + fakeServer.getLocalPort(),
+                    "security.protocol", "SSL",
+                    "ssl.endpoint.identification.algorithm", "",
                     "request.timeout.ms", "500",
                     "default.api.timeout.ms", "500",
-                    "reconnect.backoff.ms", "100",
-                    "reconnect.backoff.max.ms", "200"
+                    "reconnect.backoff.ms", "50",
+                    "reconnect.backoff.max.ms", "100"
                 )))
                 .pollDuration(Property.ofValue(Duration.ofSeconds(2)))
-                .reconnectBackoffMax(Property.ofValue(Duration.ofMillis(500)))
+                .reconnectBackoffMax(Property.ofValue(Duration.ofMillis(200)))
                 .maxReconnectAttempts(Property.ofValue(3))
                 .build();
 
@@ -341,7 +348,7 @@ class RealtimeTriggerTest {
                     completedLatch.countDown();
                 }, completedLatch::countDown);
 
-            // 3 attempts + backoffs: 3*(500ms request timeout + 100..500ms backoff) ≈ 5s; 30s is safe
+            // SSL handshake failure triggers exception quickly; 3 attempts + short backoffs ≈ 5s; 30s is safe
             boolean completed = completedLatch.await(30, TimeUnit.SECONDS);
             assertThat("Trigger must self-terminate after maxReconnectAttempts", completed, is(true));
             assertThat("Expected fluxSink.error() to be called", errors, not(empty()));

--- a/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
@@ -27,6 +27,8 @@ import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -231,6 +233,173 @@ class RealtimeTriggerTest {
             );
         } finally {
             triggerLogger.detachAppender(listAppender);
+        }
+    }
+
+    @Test
+    void shouldBackOffWhenBrokerUnreachable_consumer() throws Exception {
+        var triggerId = IdUtils.create();
+        var deadPort = findFreePort();
+
+        var trigger = RealtimeTrigger.builder()
+            .id(triggerId)
+            .type(RealtimeTrigger.class.getName())
+            .topic("dead-broker-topic")
+            .groupId(Property.ofValue("test-group-" + IdUtils.create()))
+            .properties(Property.ofValue(Map.of(
+                "bootstrap.servers", "localhost:" + deadPort,
+                // short timeouts so the test does not wait for Kafka's default 60s
+                "request.timeout.ms", "500",
+                "default.api.timeout.ms", "500",
+                "connections.max.idle.ms", "1000",
+                "reconnect.backoff.ms", "100",
+                "reconnect.backoff.max.ms", "200"
+            )))
+            .pollDuration(Property.ofValue(Duration.ofMillis(300)))
+            .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(2)))
+            .build();
+
+        var contextLogger = (ch.qos.logback.classic.Logger) runContextFactory.of(Map.of()).logger();
+        contextLogger.setLevel(ch.qos.logback.classic.Level.WARN);
+        var listAppender = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+        listAppender.setContext(contextLogger.getLoggerContext());
+        listAppender.start();
+        contextLogger.addAppender(listAppender);
+
+        try {
+            RunContext runContext = runContextFactory.of(Map.of());
+            // attach appender to the actual run context logger
+            var rcLogger = (ch.qos.logback.classic.Logger) runContext.logger();
+            rcLogger.setLevel(ch.qos.logback.classic.Level.WARN);
+            rcLogger.addAppender(listAppender);
+
+            Consume task = trigger.consumeTask();
+            var errorList = new CopyOnWriteArrayList<Throwable>();
+
+            Flux.from(trigger.publisher(task, runContext))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(record -> {}, errorList::add);
+
+            // Give the loop a short window — if it busy-spins we'd see hundreds of iterations
+            // in this interval; with backoff it should sleep most of the time
+            long start = System.currentTimeMillis();
+            Thread.sleep(Duration.ofSeconds(4).toMillis());
+            trigger.stop();
+
+            long elapsed = System.currentTimeMillis() - start;
+
+            // At least one WARN about broker unreachability must appear
+            var warnMessages = listAppender.list.stream()
+                .filter(e -> e.getLevel() == ch.qos.logback.classic.Level.WARN)
+                .map(ch.qos.logback.classic.spi.ILoggingEvent::getFormattedMessage)
+                .toList();
+
+            assertThat(
+                "Expected at least one WARN log about unreachable broker",
+                warnMessages.stream().anyMatch(m -> m.contains("broker unreachable") || m.contains("retrying")),
+                is(true)
+            );
+
+            // Verify stop() completes promptly — well within the test timeout
+            assertThat("stop() must complete within 4s window", elapsed, lessThan(6000L));
+        } finally {
+            contextLogger.detachAppender(listAppender);
+        }
+    }
+
+    @Test
+    void shouldFailAfterMaxReconnectAttempts() throws Exception {
+        var triggerId = IdUtils.create();
+        var deadPort = findFreePort();
+
+        var trigger = RealtimeTrigger.builder()
+            .id(triggerId)
+            .type(RealtimeTrigger.class.getName())
+            .topic("dead-broker-topic")
+            .groupId(Property.ofValue("test-group-" + IdUtils.create()))
+            .properties(Property.ofValue(Map.of(
+                "bootstrap.servers", "localhost:" + deadPort,
+                "request.timeout.ms", "500",
+                "default.api.timeout.ms", "500",
+                "connections.max.idle.ms", "1000",
+                "reconnect.backoff.ms", "100",
+                "reconnect.backoff.max.ms", "200"
+            )))
+            .pollDuration(Property.ofValue(Duration.ofMillis(300)))
+            .reconnectBackoffMax(Property.ofValue(Duration.ofMillis(500)))
+            .maxReconnectAttempts(Property.ofValue(3))
+            .build();
+
+        RunContext runContext = runContextFactory.of(Map.of());
+        Consume task = trigger.consumeTask();
+        var errors = new CopyOnWriteArrayList<Throwable>();
+        var completedLatch = new CountDownLatch(1);
+
+        Flux.from(trigger.publisher(task, runContext))
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe(record -> {}, err -> {
+                errors.add(err);
+                completedLatch.countDown();
+            }, completedLatch::countDown);
+
+        boolean completed = completedLatch.await(20, TimeUnit.SECONDS);
+        assertThat("Trigger must self-terminate after maxReconnectAttempts", completed, is(true));
+        assertThat("Expected fluxSink.error() to be called", errors, not(empty()));
+        assertThat(
+            "Error message must mention maxReconnectAttempts",
+            errors.getFirst().getMessage(),
+            containsString("maxReconnectAttempts=3")
+        );
+    }
+
+    @Test
+    void shouldTerminatePromptlyDuringBackoff() throws Exception {
+        var triggerId = IdUtils.create();
+        var deadPort = findFreePort();
+
+        var trigger = RealtimeTrigger.builder()
+            .id(triggerId)
+            .type(RealtimeTrigger.class.getName())
+            .topic("dead-broker-topic")
+            .groupId(Property.ofValue("test-group-" + IdUtils.create()))
+            .properties(Property.ofValue(Map.of(
+                "bootstrap.servers", "localhost:" + deadPort,
+                "request.timeout.ms", "500",
+                "default.api.timeout.ms", "500",
+                "connections.max.idle.ms", "1000",
+                "reconnect.backoff.ms", "100",
+                "reconnect.backoff.max.ms", "200"
+            )))
+            .pollDuration(Property.ofValue(Duration.ofMillis(300)))
+            // large backoff so stop() definitely interrupts a sleep
+            .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(30)))
+            .build();
+
+        RunContext runContext = runContextFactory.of(Map.of());
+        Consume task = trigger.consumeTask();
+        var completedLatch = new CountDownLatch(1);
+
+        Flux.from(trigger.publisher(task, runContext))
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe(record -> {}, err -> completedLatch.countDown(), completedLatch::countDown);
+
+        // Wait until the loop enters backoff (first failure spin takes ~pollDuration + initial backoff ~1s)
+        Thread.sleep(Duration.ofSeconds(3).toMillis());
+
+        long stopStart = System.currentTimeMillis();
+        trigger.stop();
+        // stop() is non-blocking, but the flux completes asynchronously
+        boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
+        long stopMs = System.currentTimeMillis() - stopStart;
+
+        assertThat("Trigger must terminate within 5s of stop()", terminated, is(true));
+        assertThat("stop() must not block longer than 5s", stopMs, lessThan(5000L));
+    }
+
+    private static int findFreePort() throws IOException {
+        try (var socket = new ServerSocket(0)) {
+            // close the socket so the port is released; we just need an unused port number
+            return socket.getLocalPort();
         }
     }
 

--- a/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
@@ -30,7 +30,6 @@ import reactor.core.scheduler.Schedulers;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -239,24 +238,24 @@ class RealtimeTriggerTest {
     }
 
     /**
-     * Starts a server socket that accepts connections and sends a garbage payload before closing.
-     * This causes Kafka's network layer to fail the protocol handshake and throw an exception
-     * during poll() rather than silently returning empty (which happens with plain EOF).
+     * Starts a server socket that accepts connections and keeps them open without sending any data.
+     * Kafka connects successfully but times out waiting for protocol responses, eventually throwing
+     * TimeoutException when request.timeout.ms is exceeded. This is more reliable than accept-and-close
+     * (which Kafka handles silently) across different OS/network configurations.
      * The caller is responsible for closing the returned socket after the test.
      */
     private static ServerSocket startNonKafkaServer() throws IOException {
         var server = new ServerSocket(0);
         var executor = Executors.newSingleThreadExecutor();
         executor.submit(() -> {
+            var openSockets = new java.util.ArrayList<java.net.Socket>();
             while (!server.isClosed()) {
                 try {
-                    var client = server.accept();
-                    // send garbage to break the Kafka protocol handshake, then close
-                    client.getOutputStream().write(new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
-                    client.getOutputStream().flush();
-                    client.close();
+                    // accept and keep open — Kafka's request will time out waiting for response
+                    openSockets.add(server.accept());
                 } catch (IOException ignored) {
-                    // server closed or client error — continue
+                    // server closed — clean up
+                    openSockets.forEach(s -> { try { s.close(); } catch (IOException ignored2) {} });
                 }
             }
         });
@@ -268,7 +267,8 @@ class RealtimeTriggerTest {
     void shouldBackOffWhenBrokerUnreachable_consumer() throws Exception {
         var triggerId = IdUtils.create();
 
-        // Use a server that accepts-and-closes connections; Kafka gets EOF and throws, triggering backoff
+        // Hanging server: accepts connections but never responds. Kafka polls return empty or
+        // throw (after request.timeout.ms). Either way the trigger must not crash.
         try (var fakeServer = startNonKafkaServer()) {
             var trigger = RealtimeTrigger.builder()
                 .id(triggerId)
@@ -277,12 +277,12 @@ class RealtimeTriggerTest {
                 .groupId(Property.ofValue("test-group-" + IdUtils.create()))
                 .properties(Property.ofValue(Map.of(
                     "bootstrap.servers", "localhost:" + fakeServer.getLocalPort(),
-                    "request.timeout.ms", "500",
-                    "default.api.timeout.ms", "500",
-                    "reconnect.backoff.ms", "100",
-                    "reconnect.backoff.max.ms", "200"
+                    "request.timeout.ms", "1000",
+                    "default.api.timeout.ms", "1000",
+                    "reconnect.backoff.ms", "50",
+                    "reconnect.backoff.max.ms", "100"
                 )))
-                .pollDuration(Property.ofValue(Duration.ofSeconds(2)))
+                .pollDuration(Property.ofValue(Duration.ofSeconds(3)))
                 .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(2)))
                 .build();
 
@@ -298,11 +298,11 @@ class RealtimeTriggerTest {
                     completedLatch.countDown();
                 }, completedLatch::countDown);
 
-            // Let the loop run for 6 seconds while backing off, then stop it
+            // Let it run for a bounded window then stop
             Thread.sleep(Duration.ofSeconds(6).toMillis());
             trigger.stop();
 
-            // Trigger must still be alive (retrying) — must NOT have crashed with an error
+            // Trigger must stay alive (retrying) — must NOT have crashed with an error
             assertThat("Trigger must not fail with an error during backoff retries", errors, empty());
 
             boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
@@ -313,51 +313,68 @@ class RealtimeTriggerTest {
     @Test
     void shouldFailAfterMaxReconnectAttempts() throws Exception {
         var triggerId = IdUtils.create();
+        // Use a topic with an incompatible deserializer. Produce a plain STRING record, then
+        // consume it with a JSON deserializer — Kafka throws SerializationException from poll().
+        // This is a reliable way to trigger exception-based failure spins against the real broker.
+        // fixed topic name so CI reuses it across runs; auto-created on first use
+        var topic = "tu_max_reconnect";
 
-        // Use SSL with no valid keystore to force Kafka to throw AuthenticationException / SSLException
-        // during every poll attempt. This guarantees exception-based failure spins regardless of network.
-        try (var fakeServer = startNonKafkaServer()) {
-            var trigger = RealtimeTrigger.builder()
-                .id(triggerId)
-                .type(RealtimeTrigger.class.getName())
-                .topic("dead-broker-topic")
-                .groupId(Property.ofValue("test-group-" + IdUtils.create()))
-                .properties(Property.ofValue(Map.of(
-                    "bootstrap.servers", "localhost:" + fakeServer.getLocalPort(),
-                    "security.protocol", "SSL",
-                    "ssl.endpoint.identification.algorithm", "",
-                    "request.timeout.ms", "500",
-                    "default.api.timeout.ms", "500",
-                    "reconnect.backoff.ms", "50",
-                    "reconnect.backoff.max.ms", "100"
-                )))
-                .pollDuration(Property.ofValue(Duration.ofSeconds(2)))
-                .reconnectBackoffMax(Property.ofValue(Duration.ofMillis(200)))
-                .maxReconnectAttempts(Property.ofValue(3))
-                .build();
+        // Produce one record with STRING serializer (non-transactional for simplicity)
+        Produce producer = Produce.builder()
+            .id(IdUtils.create())
+            .type(Produce.class.getName())
+            .properties(Property.ofValue(Map.of(
+                "bootstrap.servers", this.bootstrap,
+                "max.block.ms", "5000"
+            )))
+            .transactional(Property.ofValue(false))
+            .keySerializer(Property.ofValue(SerdeType.STRING))
+            .valueSerializer(Property.ofValue(SerdeType.STRING))
+            .topic(Property.ofValue(topic))
+            .from(List.of(Map.of("key", "k", "value", "not-valid-json")))
+            .build();
+        producer.run(TestsUtils.mockRunContext(runContextFactory, producer, Map.of()));
 
-            RunContext runContext = runContextFactory.of(Map.of());
-            Consume task = trigger.consumeTask();
-            var errors = new CopyOnWriteArrayList<Throwable>();
-            var completedLatch = new CountDownLatch(1);
+        var trigger = RealtimeTrigger.builder()
+            .id(triggerId)
+            .type(RealtimeTrigger.class.getName())
+            .topic(topic)
+            .groupId(Property.ofValue("test-group-" + IdUtils.create()))
+            .properties(Property.ofValue(Map.of(
+                "bootstrap.servers", this.bootstrap,
+                "auto.offset.reset", "earliest"
+            )))
+            .serdeProperties(Property.ofValue(Map.of("schema.registry.url", this.registry)))
+            .keyDeserializer(Property.ofValue(SerdeType.STRING))
+            // JSON deserializer on a non-JSON value causes SerializationException in poll().
+            // serdeProperties points at the real registry so configure() succeeds; the error
+            // fires at deserialize() time when parsing the raw STRING bytes.
+            .valueDeserializer(Property.ofValue(SerdeType.JSON))
+            .maxReconnectAttempts(Property.ofValue(1))
+            .reconnectBackoffMax(Property.ofValue(Duration.ofMillis(500)))
+            .build();
 
-            Flux.from(trigger.publisher(task, runContext))
-                .subscribeOn(Schedulers.boundedElastic())
-                .subscribe(record -> {}, err -> {
-                    errors.add(err);
-                    completedLatch.countDown();
-                }, completedLatch::countDown);
+        RunContext runContext = runContextFactory.of(Map.of());
+        Consume task = trigger.consumeTask();
+        var errors = new CopyOnWriteArrayList<Throwable>();
+        var completedLatch = new CountDownLatch(1);
 
-            // SSL handshake failure triggers exception quickly; 3 attempts + short backoffs ≈ 5s; 30s is safe
-            boolean completed = completedLatch.await(30, TimeUnit.SECONDS);
-            assertThat("Trigger must self-terminate after maxReconnectAttempts", completed, is(true));
-            assertThat("Expected fluxSink.error() to be called", errors, not(empty()));
-            assertThat(
-                "Error message must mention maxReconnectAttempts",
-                errors.getFirst().getMessage(),
-                containsString("maxReconnectAttempts=3")
-            );
-        }
+        Flux.from(trigger.publisher(task, runContext))
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe(record -> {}, err -> {
+                errors.add(err);
+                completedLatch.countDown();
+            }, completedLatch::countDown);
+
+        // 1 exception (SerializationException) + 1 backoff ≈ 2-5s; 30s is generous
+        boolean completed = completedLatch.await(30, TimeUnit.SECONDS);
+        assertThat("Trigger must self-terminate after maxReconnectAttempts", completed, is(true));
+        assertThat("Expected fluxSink.error() to be called", errors, not(empty()));
+        assertThat(
+            "Error message must mention maxReconnectAttempts",
+            errors.getFirst().getMessage(),
+            containsString("maxReconnectAttempts=1")
+        );
     }
 
     @Test
@@ -372,13 +389,14 @@ class RealtimeTriggerTest {
                 .groupId(Property.ofValue("test-group-" + IdUtils.create()))
                 .properties(Property.ofValue(Map.of(
                     "bootstrap.servers", "localhost:" + fakeServer.getLocalPort(),
-                    "request.timeout.ms", "500",
-                    "default.api.timeout.ms", "500",
-                    "reconnect.backoff.ms", "100",
-                    "reconnect.backoff.max.ms", "200"
+                    "request.timeout.ms", "1000",
+                    "default.api.timeout.ms", "1000",
+                    "reconnect.backoff.ms", "50",
+                    "reconnect.backoff.max.ms", "100"
                 )))
-                .pollDuration(Property.ofValue(Duration.ofSeconds(2)))
-                // large backoff so stop() definitely interrupts a sleep
+                .pollDuration(Property.ofValue(Duration.ofSeconds(3)))
+                // large backoff so stop() definitely interrupts a sleep (if exceptions fire)
+                // or wakeup() interrupts the poll (if Kafka returns silently)
                 .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(30)))
                 .build();
 
@@ -390,12 +408,12 @@ class RealtimeTriggerTest {
                 .subscribeOn(Schedulers.boundedElastic())
                 .subscribe(record -> {}, err -> completedLatch.countDown(), completedLatch::countDown);
 
-            // Wait until the loop has entered the long backoff sleep (initial 1s backoff)
-            Thread.sleep(Duration.ofSeconds(4).toMillis());
+            // Wait until the loop has had time to run at least one poll
+            Thread.sleep(Duration.ofSeconds(5).toMillis());
 
             long stopStart = System.currentTimeMillis();
             trigger.stop();
-            // stop() is non-blocking; Thread::interrupt wakes up the backoff sleep immediately
+            // wakeup() breaks any ongoing poll; Thread::interrupt breaks any backoff sleep
             boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
             long stopMs = System.currentTimeMillis() - stopStart;
 

--- a/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
@@ -282,8 +282,6 @@ class RealtimeTriggerTest {
                     "reconnect.backoff.ms", "50",
                     "reconnect.backoff.max.ms", "100"
                 )))
-                .pollDuration(Property.ofValue(Duration.ofSeconds(3)))
-                .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(2)))
                 .build();
 
             RunContext runContext = runContextFactory.of(Map.of());
@@ -311,70 +309,45 @@ class RealtimeTriggerTest {
     }
 
     @Test
-    void shouldFailAfterMaxReconnectAttempts() throws Exception {
+    void shouldBackOffWhenBrokerUnreachable_share() throws Exception {
         var triggerId = IdUtils.create();
-        // Use a topic with an incompatible deserializer. Produce a plain STRING record, then
-        // consume it with a JSON deserializer — Kafka throws SerializationException from poll().
-        // This is a reliable way to trigger exception-based failure spins against the real broker.
-        // fixed topic name so CI reuses it across runs; auto-created on first use
-        var topic = "tu_max_reconnect";
 
-        // Produce one record with STRING serializer (non-transactional for simplicity)
-        Produce producer = Produce.builder()
-            .id(IdUtils.create())
-            .type(Produce.class.getName())
-            .properties(Property.ofValue(Map.of(
-                "bootstrap.servers", this.bootstrap,
-                "max.block.ms", "5000"
-            )))
-            .transactional(Property.ofValue(false))
-            .keySerializer(Property.ofValue(SerdeType.STRING))
-            .valueSerializer(Property.ofValue(SerdeType.STRING))
-            .topic(Property.ofValue(topic))
-            .from(List.of(Map.of("key", "k", "value", "not-valid-json")))
-            .build();
-        producer.run(TestsUtils.mockRunContext(runContextFactory, producer, Map.of()));
+        try (var fakeServer = startNonKafkaServer()) {
+            var trigger = RealtimeTrigger.builder()
+                .id(triggerId)
+                .type(RealtimeTrigger.class.getName())
+                .topic("dead-broker-topic-share")
+                .groupId(Property.ofValue("test-share-group-" + IdUtils.create()))
+                .groupType(Property.ofValue(GroupType.SHARE))
+                .properties(Property.ofValue(Map.of(
+                    "bootstrap.servers", "localhost:" + fakeServer.getLocalPort(),
+                    "request.timeout.ms", "1000",
+                    "default.api.timeout.ms", "1000",
+                    "reconnect.backoff.ms", "50",
+                    "reconnect.backoff.max.ms", "100"
+                )))
+                .build();
 
-        var trigger = RealtimeTrigger.builder()
-            .id(triggerId)
-            .type(RealtimeTrigger.class.getName())
-            .topic(topic)
-            .groupId(Property.ofValue("test-group-" + IdUtils.create()))
-            .properties(Property.ofValue(Map.of(
-                "bootstrap.servers", this.bootstrap,
-                "auto.offset.reset", "earliest"
-            )))
-            .serdeProperties(Property.ofValue(Map.of("schema.registry.url", this.registry)))
-            .keyDeserializer(Property.ofValue(SerdeType.STRING))
-            // JSON deserializer on a non-JSON value causes SerializationException in poll().
-            // serdeProperties points at the real registry so configure() succeeds; the error
-            // fires at deserialize() time when parsing the raw STRING bytes.
-            .valueDeserializer(Property.ofValue(SerdeType.JSON))
-            .maxReconnectAttempts(Property.ofValue(1))
-            .reconnectBackoffMax(Property.ofValue(Duration.ofMillis(500)))
-            .build();
+            RunContext runContext = runContextFactory.of(Map.of());
+            Consume task = trigger.consumeTask();
+            var errors = new CopyOnWriteArrayList<Throwable>();
+            var completedLatch = new CountDownLatch(1);
 
-        RunContext runContext = runContextFactory.of(Map.of());
-        Consume task = trigger.consumeTask();
-        var errors = new CopyOnWriteArrayList<Throwable>();
-        var completedLatch = new CountDownLatch(1);
+            Flux.from(trigger.publisher(task, runContext))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(record -> {}, err -> {
+                    errors.add(err);
+                    completedLatch.countDown();
+                }, completedLatch::countDown);
 
-        Flux.from(trigger.publisher(task, runContext))
-            .subscribeOn(Schedulers.boundedElastic())
-            .subscribe(record -> {}, err -> {
-                errors.add(err);
-                completedLatch.countDown();
-            }, completedLatch::countDown);
+            Thread.sleep(Duration.ofSeconds(6).toMillis());
+            trigger.stop();
 
-        // 1 exception (SerializationException) + 1 backoff ≈ 2-5s; 30s is generous
-        boolean completed = completedLatch.await(30, TimeUnit.SECONDS);
-        assertThat("Trigger must self-terminate after maxReconnectAttempts", completed, is(true));
-        assertThat("Expected fluxSink.error() to be called", errors, not(empty()));
-        assertThat(
-            "Error message must mention maxReconnectAttempts",
-            errors.getFirst().getMessage(),
-            containsString("maxReconnectAttempts=1")
-        );
+            assertThat("SHARE trigger must not fail with an error during backoff retries", errors, empty());
+
+            boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
+            assertThat("SHARE trigger must terminate within 5s of stop()", terminated, is(true));
+        }
     }
 
     @Test
@@ -394,10 +367,6 @@ class RealtimeTriggerTest {
                     "reconnect.backoff.ms", "50",
                     "reconnect.backoff.max.ms", "100"
                 )))
-                .pollDuration(Property.ofValue(Duration.ofSeconds(3)))
-                // large backoff so stop() definitely interrupts a sleep (if exceptions fire)
-                // or wakeup() interrupts the poll (if Kafka returns silently)
-                .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(30)))
                 .build();
 
             RunContext runContext = runContextFactory.of(Map.of());
@@ -408,7 +377,7 @@ class RealtimeTriggerTest {
                 .subscribeOn(Schedulers.boundedElastic())
                 .subscribe(record -> {}, err -> completedLatch.countDown(), completedLatch::countDown);
 
-            // Wait until the loop has had time to run at least one poll
+            // Wait until the loop has had time to run at least one poll and enter backoff
             Thread.sleep(Duration.ofSeconds(5).toMillis());
 
             long stopStart = System.currentTimeMillis();

--- a/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
@@ -264,11 +264,11 @@ class RealtimeTriggerTest {
     }
 
     @Test
-    void shouldBackOffWhenBrokerUnreachable_consumer() throws Exception {
+    void shouldNotBusyLoopWhenBrokerUnreachable_consumer() throws Exception {
         var triggerId = IdUtils.create();
 
-        // Hanging server: accepts connections but never responds. Kafka polls return empty or
-        // throw (after request.timeout.ms). Either way the trigger must not crash.
+        // Hanging server: accepts connections but never responds. The bounded poll timeout keeps
+        // the loop from busy-spinning; polls return empty without crashing the trigger.
         try (var fakeServer = startNonKafkaServer()) {
             var trigger = RealtimeTrigger.builder()
                 .id(triggerId)
@@ -300,8 +300,8 @@ class RealtimeTriggerTest {
             Thread.sleep(Duration.ofSeconds(6).toMillis());
             trigger.stop();
 
-            // Trigger must stay alive (retrying) — must NOT have crashed with an error
-            assertThat("Trigger must not fail with an error during backoff retries", errors, empty());
+            // Trigger must stay alive (polling) — must NOT have crashed with an error
+            assertThat("Trigger must not fail with an error while the broker is unreachable", errors, empty());
 
             boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
             assertThat("Trigger must terminate within 5s of stop()", terminated, is(true));
@@ -309,7 +309,7 @@ class RealtimeTriggerTest {
     }
 
     @Test
-    void shouldBackOffWhenBrokerUnreachable_share() throws Exception {
+    void shouldNotBusyLoopWhenBrokerUnreachable_share() throws Exception {
         var triggerId = IdUtils.create();
 
         try (var fakeServer = startNonKafkaServer()) {
@@ -343,7 +343,7 @@ class RealtimeTriggerTest {
             Thread.sleep(Duration.ofSeconds(6).toMillis());
             trigger.stop();
 
-            assertThat("SHARE trigger must not fail with an error during backoff retries", errors, empty());
+            assertThat("SHARE trigger must not fail with an error while the broker is unreachable", errors, empty());
 
             boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
             assertThat("SHARE trigger must terminate within 5s of stop()", terminated, is(true));
@@ -351,7 +351,7 @@ class RealtimeTriggerTest {
     }
 
     @Test
-    void shouldTerminatePromptlyDuringBackoff() throws Exception {
+    void shouldTerminatePromptlyWhenBrokerUnreachable() throws Exception {
         var triggerId = IdUtils.create();
 
         try (var fakeServer = startNonKafkaServer()) {
@@ -377,12 +377,12 @@ class RealtimeTriggerTest {
                 .subscribeOn(Schedulers.boundedElastic())
                 .subscribe(record -> {}, err -> completedLatch.countDown(), completedLatch::countDown);
 
-            // Wait until the loop has had time to run at least one poll and enter backoff
+            // Wait until the loop has had time to run at least one poll against the dead broker
             Thread.sleep(Duration.ofSeconds(5).toMillis());
 
             long stopStart = System.currentTimeMillis();
             trigger.stop();
-            // wakeup() breaks any ongoing poll; Thread::interrupt breaks any backoff sleep
+            // wakeup() breaks the blocking poll so the loop exits promptly
             boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
             long stopMs = System.currentTimeMillis() - stopStart;
 

--- a/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
@@ -29,6 +29,7 @@ import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.concurrent.Executors;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -236,140 +237,163 @@ class RealtimeTriggerTest {
         }
     }
 
+    /**
+     * Starts a server socket that accepts connections but never speaks the Kafka protocol.
+     * Kafka will connect successfully but get garbage/no data, causing it to throw exceptions
+     * during poll() regardless of network filtering (firewall/iptables). The caller is responsible
+     * for closing the returned socket after the test.
+     */
+    private static ServerSocket startNonKafkaServer() throws IOException {
+        var server = new ServerSocket(0);
+        var executor = Executors.newSingleThreadExecutor();
+        // accept connections in background and immediately close them so Kafka gets EOF
+        executor.submit(() -> {
+            while (!server.isClosed()) {
+                try {
+                    server.accept().close();
+                } catch (IOException ignored) {
+                    // server closed — stop accepting
+                }
+            }
+        });
+        executor.shutdown();
+        return server;
+    }
+
     @Test
     void shouldBackOffWhenBrokerUnreachable_consumer() throws Exception {
         var triggerId = IdUtils.create();
-        var deadPort = findFreePort();
 
-        // pollDuration=100ms → idleThreshold=20ms; connection-refused returns in <1ms so triggers backoff
-        var trigger = RealtimeTrigger.builder()
-            .id(triggerId)
-            .type(RealtimeTrigger.class.getName())
-            .topic("dead-broker-topic")
-            .groupId(Property.ofValue("test-group-" + IdUtils.create()))
-            .properties(Property.ofValue(Map.of(
-                "bootstrap.servers", "localhost:" + deadPort,
-                "request.timeout.ms", "200",
-                "default.api.timeout.ms", "200"
-            )))
-            .pollDuration(Property.ofValue(Duration.ofMillis(100)))
-            // cap backoff at 1s so the 4s window covers at least a few retry cycles
-            .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(1)))
-            .build();
+        // Use a server that accepts-and-closes connections; Kafka gets EOF and throws, triggering backoff
+        try (var fakeServer = startNonKafkaServer()) {
+            var trigger = RealtimeTrigger.builder()
+                .id(triggerId)
+                .type(RealtimeTrigger.class.getName())
+                .topic("dead-broker-topic")
+                .groupId(Property.ofValue("test-group-" + IdUtils.create()))
+                .properties(Property.ofValue(Map.of(
+                    "bootstrap.servers", "localhost:" + fakeServer.getLocalPort(),
+                    "request.timeout.ms", "500",
+                    "default.api.timeout.ms", "500",
+                    "reconnect.backoff.ms", "100",
+                    "reconnect.backoff.max.ms", "200"
+                )))
+                .pollDuration(Property.ofValue(Duration.ofSeconds(2)))
+                .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(2)))
+                .build();
 
-        RunContext runContext = runContextFactory.of(Map.of());
-        Consume task = trigger.consumeTask();
-        var errors = new CopyOnWriteArrayList<Throwable>();
-        var completedLatch = new CountDownLatch(1);
+            RunContext runContext = runContextFactory.of(Map.of());
+            Consume task = trigger.consumeTask();
+            var errors = new CopyOnWriteArrayList<Throwable>();
+            var completedLatch = new CountDownLatch(1);
 
-        Flux.from(trigger.publisher(task, runContext))
-            .subscribeOn(Schedulers.boundedElastic())
-            .subscribe(record -> {}, err -> {
-                errors.add(err);
-                completedLatch.countDown();
-            }, completedLatch::countDown);
+            Flux.from(trigger.publisher(task, runContext))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(record -> {}, err -> {
+                    errors.add(err);
+                    completedLatch.countDown();
+                }, completedLatch::countDown);
 
-        // Let the loop run for 4 seconds while backing off, then stop it
-        Thread.sleep(Duration.ofSeconds(4).toMillis());
-        trigger.stop();
+            // Let the loop run for 6 seconds while backing off, then stop it
+            Thread.sleep(Duration.ofSeconds(6).toMillis());
+            trigger.stop();
 
-        // Trigger must still be alive (retrying) — it must NOT have crashed with an error
-        assertThat("Trigger must not fail with an error during backoff retries", errors, empty());
+            // Trigger must still be alive (retrying) — must NOT have crashed with an error
+            assertThat("Trigger must not fail with an error during backoff retries", errors, empty());
 
-        // stop() must terminate the flux within a reasonable window
-        boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
-        assertThat("Trigger must terminate within 5s of stop()", terminated, is(true));
+            boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
+            assertThat("Trigger must terminate within 5s of stop()", terminated, is(true));
+        }
     }
 
     @Test
     void shouldFailAfterMaxReconnectAttempts() throws Exception {
         var triggerId = IdUtils.create();
-        var deadPort = findFreePort();
 
-        // pollDuration=100ms → idleThreshold=20ms; each failure spin triggers backoff
-        // With maxReconnectAttempts=3 and backoff cap=200ms: ~3*(100ms + 100..200ms) ≈ 1s total
-        var trigger = RealtimeTrigger.builder()
-            .id(triggerId)
-            .type(RealtimeTrigger.class.getName())
-            .topic("dead-broker-topic")
-            .groupId(Property.ofValue("test-group-" + IdUtils.create()))
-            .properties(Property.ofValue(Map.of(
-                "bootstrap.servers", "localhost:" + deadPort,
-                "request.timeout.ms", "200",
-                "default.api.timeout.ms", "200"
-            )))
-            .pollDuration(Property.ofValue(Duration.ofMillis(100)))
-            .reconnectBackoffMax(Property.ofValue(Duration.ofMillis(200)))
-            .maxReconnectAttempts(Property.ofValue(3))
-            .build();
+        // Use a server that accepts-and-closes connections; Kafka gets EOF and throws
+        try (var fakeServer = startNonKafkaServer()) {
+            var trigger = RealtimeTrigger.builder()
+                .id(triggerId)
+                .type(RealtimeTrigger.class.getName())
+                .topic("dead-broker-topic")
+                .groupId(Property.ofValue("test-group-" + IdUtils.create()))
+                .properties(Property.ofValue(Map.of(
+                    "bootstrap.servers", "localhost:" + fakeServer.getLocalPort(),
+                    "request.timeout.ms", "500",
+                    "default.api.timeout.ms", "500",
+                    "reconnect.backoff.ms", "100",
+                    "reconnect.backoff.max.ms", "200"
+                )))
+                .pollDuration(Property.ofValue(Duration.ofSeconds(2)))
+                .reconnectBackoffMax(Property.ofValue(Duration.ofMillis(500)))
+                .maxReconnectAttempts(Property.ofValue(3))
+                .build();
 
-        RunContext runContext = runContextFactory.of(Map.of());
-        Consume task = trigger.consumeTask();
-        var errors = new CopyOnWriteArrayList<Throwable>();
-        var completedLatch = new CountDownLatch(1);
+            RunContext runContext = runContextFactory.of(Map.of());
+            Consume task = trigger.consumeTask();
+            var errors = new CopyOnWriteArrayList<Throwable>();
+            var completedLatch = new CountDownLatch(1);
 
-        Flux.from(trigger.publisher(task, runContext))
-            .subscribeOn(Schedulers.boundedElastic())
-            .subscribe(record -> {}, err -> {
-                errors.add(err);
-                completedLatch.countDown();
-            }, completedLatch::countDown);
+            Flux.from(trigger.publisher(task, runContext))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(record -> {}, err -> {
+                    errors.add(err);
+                    completedLatch.countDown();
+                }, completedLatch::countDown);
 
-        boolean completed = completedLatch.await(30, TimeUnit.SECONDS);
-        assertThat("Trigger must self-terminate after maxReconnectAttempts", completed, is(true));
-        assertThat("Expected fluxSink.error() to be called", errors, not(empty()));
-        assertThat(
-            "Error message must mention maxReconnectAttempts",
-            errors.getFirst().getMessage(),
-            containsString("maxReconnectAttempts=3")
-        );
+            // 3 attempts + backoffs: 3*(500ms request timeout + 100..500ms backoff) ≈ 5s; 30s is safe
+            boolean completed = completedLatch.await(30, TimeUnit.SECONDS);
+            assertThat("Trigger must self-terminate after maxReconnectAttempts", completed, is(true));
+            assertThat("Expected fluxSink.error() to be called", errors, not(empty()));
+            assertThat(
+                "Error message must mention maxReconnectAttempts",
+                errors.getFirst().getMessage(),
+                containsString("maxReconnectAttempts=3")
+            );
+        }
     }
 
     @Test
     void shouldTerminatePromptlyDuringBackoff() throws Exception {
         var triggerId = IdUtils.create();
-        var deadPort = findFreePort();
 
-        var trigger = RealtimeTrigger.builder()
-            .id(triggerId)
-            .type(RealtimeTrigger.class.getName())
-            .topic("dead-broker-topic")
-            .groupId(Property.ofValue("test-group-" + IdUtils.create()))
-            .properties(Property.ofValue(Map.of(
-                "bootstrap.servers", "localhost:" + deadPort,
-                "request.timeout.ms", "200",
-                "default.api.timeout.ms", "200"
-            )))
-            .pollDuration(Property.ofValue(Duration.ofMillis(100)))
-            // large backoff so stop() definitely interrupts a sleep
-            .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(30)))
-            .build();
+        try (var fakeServer = startNonKafkaServer()) {
+            var trigger = RealtimeTrigger.builder()
+                .id(triggerId)
+                .type(RealtimeTrigger.class.getName())
+                .topic("dead-broker-topic")
+                .groupId(Property.ofValue("test-group-" + IdUtils.create()))
+                .properties(Property.ofValue(Map.of(
+                    "bootstrap.servers", "localhost:" + fakeServer.getLocalPort(),
+                    "request.timeout.ms", "500",
+                    "default.api.timeout.ms", "500",
+                    "reconnect.backoff.ms", "100",
+                    "reconnect.backoff.max.ms", "200"
+                )))
+                .pollDuration(Property.ofValue(Duration.ofSeconds(2)))
+                // large backoff so stop() definitely interrupts a sleep
+                .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(30)))
+                .build();
 
-        RunContext runContext = runContextFactory.of(Map.of());
-        Consume task = trigger.consumeTask();
-        var completedLatch = new CountDownLatch(1);
+            RunContext runContext = runContextFactory.of(Map.of());
+            Consume task = trigger.consumeTask();
+            var completedLatch = new CountDownLatch(1);
 
-        Flux.from(trigger.publisher(task, runContext))
-            .subscribeOn(Schedulers.boundedElastic())
-            .subscribe(record -> {}, err -> completedLatch.countDown(), completedLatch::countDown);
+            Flux.from(trigger.publisher(task, runContext))
+                .subscribeOn(Schedulers.boundedElastic())
+                .subscribe(record -> {}, err -> completedLatch.countDown(), completedLatch::countDown);
 
-        // Wait until the loop has entered the long backoff sleep (1s initial, then grows to 30s)
-        Thread.sleep(Duration.ofSeconds(2).toMillis());
+            // Wait until the loop has entered the long backoff sleep (initial 1s backoff)
+            Thread.sleep(Duration.ofSeconds(4).toMillis());
 
-        long stopStart = System.currentTimeMillis();
-        trigger.stop();
-        // stop() is non-blocking, but the flux completes asynchronously via Thread.interrupt
-        boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
-        long stopMs = System.currentTimeMillis() - stopStart;
+            long stopStart = System.currentTimeMillis();
+            trigger.stop();
+            // stop() is non-blocking; Thread::interrupt wakes up the backoff sleep immediately
+            boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
+            long stopMs = System.currentTimeMillis() - stopStart;
 
-        assertThat("Trigger must terminate within 5s of stop()", terminated, is(true));
-        assertThat("stop() must not block longer than 5s", stopMs, lessThan(5000L));
-    }
-
-    private static int findFreePort() throws IOException {
-        try (var socket = new ServerSocket(0)) {
-            // close the socket so the port is released; we just need an unused port number
-            return socket.getLocalPort();
+            assertThat("Trigger must terminate within 5s of stop()", terminated, is(true));
+            assertThat("stop() must not block longer than 5s", stopMs, lessThan(5000L));
         }
     }
 

--- a/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
@@ -259,26 +259,21 @@ class RealtimeTriggerTest {
             .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(2)))
             .build();
 
-        var contextLogger = (ch.qos.logback.classic.Logger) runContextFactory.of(Map.of()).logger();
-        contextLogger.setLevel(ch.qos.logback.classic.Level.WARN);
+        RunContext runContext = runContextFactory.of(Map.of());
+        var rcLogger = (ch.qos.logback.classic.Logger) runContext.logger();
+        rcLogger.setLevel(ch.qos.logback.classic.Level.WARN);
         var listAppender = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
-        listAppender.setContext(contextLogger.getLoggerContext());
+        listAppender.setContext(rcLogger.getLoggerContext());
         listAppender.start();
-        contextLogger.addAppender(listAppender);
+        rcLogger.addAppender(listAppender);
 
         try {
-            RunContext runContext = runContextFactory.of(Map.of());
-            // attach appender to the actual run context logger
-            var rcLogger = (ch.qos.logback.classic.Logger) runContext.logger();
-            rcLogger.setLevel(ch.qos.logback.classic.Level.WARN);
-            rcLogger.addAppender(listAppender);
 
             Consume task = trigger.consumeTask();
-            var errorList = new CopyOnWriteArrayList<Throwable>();
 
             Flux.from(trigger.publisher(task, runContext))
                 .subscribeOn(Schedulers.boundedElastic())
-                .subscribe(record -> {}, errorList::add);
+                .subscribe(record -> {}, err -> {});
 
             // Give the loop a short window — if it busy-spins we'd see hundreds of iterations
             // in this interval; with backoff it should sleep most of the time
@@ -303,7 +298,7 @@ class RealtimeTriggerTest {
             // Verify stop() completes promptly — well within the test timeout
             assertThat("stop() must complete within 4s window", elapsed, lessThan(6000L));
         } finally {
-            contextLogger.detachAppender(listAppender);
+            rcLogger.detachAppender(listAppender);
         }
     }
 

--- a/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/kafka/RealtimeTriggerTest.java
@@ -241,6 +241,7 @@ class RealtimeTriggerTest {
         var triggerId = IdUtils.create();
         var deadPort = findFreePort();
 
+        // pollDuration=100ms → idleThreshold=20ms; connection-refused returns in <1ms so triggers backoff
         var trigger = RealtimeTrigger.builder()
             .id(triggerId)
             .type(RealtimeTrigger.class.getName())
@@ -248,58 +249,36 @@ class RealtimeTriggerTest {
             .groupId(Property.ofValue("test-group-" + IdUtils.create()))
             .properties(Property.ofValue(Map.of(
                 "bootstrap.servers", "localhost:" + deadPort,
-                // short timeouts so the test does not wait for Kafka's default 60s
-                "request.timeout.ms", "500",
-                "default.api.timeout.ms", "500",
-                "connections.max.idle.ms", "1000",
-                "reconnect.backoff.ms", "100",
-                "reconnect.backoff.max.ms", "200"
+                "request.timeout.ms", "200",
+                "default.api.timeout.ms", "200"
             )))
-            .pollDuration(Property.ofValue(Duration.ofMillis(300)))
-            .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(2)))
+            .pollDuration(Property.ofValue(Duration.ofMillis(100)))
+            // cap backoff at 1s so the 4s window covers at least a few retry cycles
+            .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(1)))
             .build();
 
         RunContext runContext = runContextFactory.of(Map.of());
-        var rcLogger = (ch.qos.logback.classic.Logger) runContext.logger();
-        rcLogger.setLevel(ch.qos.logback.classic.Level.WARN);
-        var listAppender = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
-        listAppender.setContext(rcLogger.getLoggerContext());
-        listAppender.start();
-        rcLogger.addAppender(listAppender);
+        Consume task = trigger.consumeTask();
+        var errors = new CopyOnWriteArrayList<Throwable>();
+        var completedLatch = new CountDownLatch(1);
 
-        try {
+        Flux.from(trigger.publisher(task, runContext))
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe(record -> {}, err -> {
+                errors.add(err);
+                completedLatch.countDown();
+            }, completedLatch::countDown);
 
-            Consume task = trigger.consumeTask();
+        // Let the loop run for 4 seconds while backing off, then stop it
+        Thread.sleep(Duration.ofSeconds(4).toMillis());
+        trigger.stop();
 
-            Flux.from(trigger.publisher(task, runContext))
-                .subscribeOn(Schedulers.boundedElastic())
-                .subscribe(record -> {}, err -> {});
+        // Trigger must still be alive (retrying) — it must NOT have crashed with an error
+        assertThat("Trigger must not fail with an error during backoff retries", errors, empty());
 
-            // Give the loop a short window — if it busy-spins we'd see hundreds of iterations
-            // in this interval; with backoff it should sleep most of the time
-            long start = System.currentTimeMillis();
-            Thread.sleep(Duration.ofSeconds(4).toMillis());
-            trigger.stop();
-
-            long elapsed = System.currentTimeMillis() - start;
-
-            // At least one WARN about broker unreachability must appear
-            var warnMessages = listAppender.list.stream()
-                .filter(e -> e.getLevel() == ch.qos.logback.classic.Level.WARN)
-                .map(ch.qos.logback.classic.spi.ILoggingEvent::getFormattedMessage)
-                .toList();
-
-            assertThat(
-                "Expected at least one WARN log about unreachable broker",
-                warnMessages.stream().anyMatch(m -> m.contains("broker unreachable") || m.contains("retrying")),
-                is(true)
-            );
-
-            // Verify stop() completes promptly — well within the test timeout
-            assertThat("stop() must complete within 4s window", elapsed, lessThan(6000L));
-        } finally {
-            rcLogger.detachAppender(listAppender);
-        }
+        // stop() must terminate the flux within a reasonable window
+        boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
+        assertThat("Trigger must terminate within 5s of stop()", terminated, is(true));
     }
 
     @Test
@@ -307,6 +286,8 @@ class RealtimeTriggerTest {
         var triggerId = IdUtils.create();
         var deadPort = findFreePort();
 
+        // pollDuration=100ms → idleThreshold=20ms; each failure spin triggers backoff
+        // With maxReconnectAttempts=3 and backoff cap=200ms: ~3*(100ms + 100..200ms) ≈ 1s total
         var trigger = RealtimeTrigger.builder()
             .id(triggerId)
             .type(RealtimeTrigger.class.getName())
@@ -314,14 +295,11 @@ class RealtimeTriggerTest {
             .groupId(Property.ofValue("test-group-" + IdUtils.create()))
             .properties(Property.ofValue(Map.of(
                 "bootstrap.servers", "localhost:" + deadPort,
-                "request.timeout.ms", "500",
-                "default.api.timeout.ms", "500",
-                "connections.max.idle.ms", "1000",
-                "reconnect.backoff.ms", "100",
-                "reconnect.backoff.max.ms", "200"
+                "request.timeout.ms", "200",
+                "default.api.timeout.ms", "200"
             )))
-            .pollDuration(Property.ofValue(Duration.ofMillis(300)))
-            .reconnectBackoffMax(Property.ofValue(Duration.ofMillis(500)))
+            .pollDuration(Property.ofValue(Duration.ofMillis(100)))
+            .reconnectBackoffMax(Property.ofValue(Duration.ofMillis(200)))
             .maxReconnectAttempts(Property.ofValue(3))
             .build();
 
@@ -337,7 +315,7 @@ class RealtimeTriggerTest {
                 completedLatch.countDown();
             }, completedLatch::countDown);
 
-        boolean completed = completedLatch.await(20, TimeUnit.SECONDS);
+        boolean completed = completedLatch.await(30, TimeUnit.SECONDS);
         assertThat("Trigger must self-terminate after maxReconnectAttempts", completed, is(true));
         assertThat("Expected fluxSink.error() to be called", errors, not(empty()));
         assertThat(
@@ -359,13 +337,10 @@ class RealtimeTriggerTest {
             .groupId(Property.ofValue("test-group-" + IdUtils.create()))
             .properties(Property.ofValue(Map.of(
                 "bootstrap.servers", "localhost:" + deadPort,
-                "request.timeout.ms", "500",
-                "default.api.timeout.ms", "500",
-                "connections.max.idle.ms", "1000",
-                "reconnect.backoff.ms", "100",
-                "reconnect.backoff.max.ms", "200"
+                "request.timeout.ms", "200",
+                "default.api.timeout.ms", "200"
             )))
-            .pollDuration(Property.ofValue(Duration.ofMillis(300)))
+            .pollDuration(Property.ofValue(Duration.ofMillis(100)))
             // large backoff so stop() definitely interrupts a sleep
             .reconnectBackoffMax(Property.ofValue(Duration.ofSeconds(30)))
             .build();
@@ -378,12 +353,12 @@ class RealtimeTriggerTest {
             .subscribeOn(Schedulers.boundedElastic())
             .subscribe(record -> {}, err -> completedLatch.countDown(), completedLatch::countDown);
 
-        // Wait until the loop enters backoff (first failure spin takes ~pollDuration + initial backoff ~1s)
-        Thread.sleep(Duration.ofSeconds(3).toMillis());
+        // Wait until the loop has entered the long backoff sleep (1s initial, then grows to 30s)
+        Thread.sleep(Duration.ofSeconds(2).toMillis());
 
         long stopStart = System.currentTimeMillis();
         trigger.stop();
-        // stop() is non-blocking, but the flux completes asynchronously
+        // stop() is non-blocking, but the flux completes asynchronously via Thread.interrupt
         boolean terminated = completedLatch.await(5, TimeUnit.SECONDS);
         long stopMs = System.currentTimeMillis() - stopStart;
 


### PR DESCRIPTION
## Summary

`RealtimeTrigger.runPollingLoop` polled with `consumer.poll(Duration.ofMillis(Long.MAX_VALUE))`. With an unbounded timeout the poll loop busy-spins when the broker is unreachable, pegging CPU (see #178).

**Fix:** bound the poll timeout to a finite internal constant (`POLL_DURATION = 2s`). `poll()` now blocks for at most 2s before the loop re-checks `isActive` and polls again, so an unreachable broker no longer causes a CPU spin. Both `CONSUMER` and `SHARE` paths share `runPollingLoop`, so both are covered. No new user-facing properties; defaults preserved.

The net source change is the `POLL_DURATION` constant plus the two `poll()` call sites.

> An earlier revision of this PR added an exponential-backoff + fast-empty heuristic + custom WARN logging path. Live QA on a Kestra EE instance showed that path **never executes** against a real unreachable/hanging broker — `KafkaConsumer.poll(Duration)` blocks for ~the full timeout and absorbs connection-refused/disconnect internally, so neither the fast-empty heuristic nor an exception fires. The bounded poll alone fixes the bug, so the dead code was removed.

## Test plan

- [x] `shouldNotBusyLoopWhenBrokerUnreachable_consumer`: points the trigger at a hanging server, runs 6s, asserts no error thrown and prompt termination on `stop()`.
- [x] `shouldNotBusyLoopWhenBrokerUnreachable_share`: same for the SHARE path.
- [x] `shouldTerminatePromptlyWhenBrokerUnreachable`: `stop()` breaks the blocking poll within 5s.
- [x] Local tests green (`./gradlew test --tests "io.kestra.plugin.kafka.RealtimeTriggerTest.*"`).
- [x] Live QA on Kestra EE: unreachable (`:9999`) and hanging (`:9998`) brokers held CPU at ~5–10% (no spin) with 0 executions and no crash; healthy CONSUMER and SHARE triggers consumed records normally.

closes: https://github.com/kestra-io/plugin-kafka/issues/178
